### PR TITLE
Create new plans with nested attributes

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -272,7 +272,8 @@ class PlansController < ApplicationController
 
   def add_operation_period
     @count = params[:count].to_i + 1
-    @operation_period = OperationPeriod.new
+    @plan = Plan.new
+    @operation_period = @plan.operation_periods.build
     respond_to do |format|
       format.js
     end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -234,6 +234,7 @@ class PlansController < ApplicationController
   def add_first_aid_station
     @first_aid_station = params[:first_aid_station]
     @operation_period = params[:operation_period]
+    @operation_period_index = params[:operation_period_index]
     respond_to do |format|
       format.js
     end
@@ -241,6 +242,7 @@ class PlansController < ApplicationController
 
   def update_first_aid_station
     @operation_period = params[:operation_period]
+    @operation_period_index = params[:operation_period_index]
     # binding.pry
     respond_to do |format|
       format.js

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -44,6 +44,8 @@ class PlansController < ApplicationController
 
   def new
     @plan = Plan.new
+    @plan.operation_periods.build
+    
     respond_to do |format|
       format.html
       format.json { render json: @plan }
@@ -51,44 +53,7 @@ class PlansController < ApplicationController
   end  
 
   def create
-    @plan = Plan.create(plan_params)
-    @plan.creator = current_user
-    @plan.owner = current_user
-    operation_periods_params[:id].each do |op|
-      @operation_period = OperationPeriod.new(attendance: op[1][:attendance])
-      @operation_period.start_date = DateTime.strptime(op[1][:start_date], '%m/%d/%Y %H:%M %p')
-      @operation_period.end_date = DateTime.strptime(op[1][:end_date], '%m/%d/%Y %H:%M %p')
-      @operation_period.save
-      @plan.operation_periods << @operation_period
-      if op[1][:first_aid_stations].present? 
-        op[1][:first_aid_stations][:id].each do |station|
-          @first_aid_station = FirstAidStation.create(station[1])
-          @operation_period.first_aid_stations << @first_aid_station
-          @operation_period.save
-        end
-      end
-      if op[1][:mobile_teams].present? 
-        op[1][:mobile_teams][:id].each do |station|
-          @mobile_team = MobileTeam.create(station[1])
-          @operation_period.mobile_teams << @mobile_team
-          @operation_period.save
-        end
-      end
-      if op[1][:transport].present? 
-        op[1][:transport][:id].each do |station|
-          @transport = Transport.create(station[1])
-          @operation_period.transports << @transport
-          @operation_period.save
-        end
-      end
-      if op[1][:dispatch].present? 
-        op[1][:dispatch][:id].each do |station|
-          @dispatch = Dispatch.create(station[1])
-          @operation_period.dispatchs << @dispatch
-          @operation_period.save
-        end
-      end
-    end
+    @plan = Plan.create(plan_params.merge(creator: current_user, owner: current_user))
 
     if params[:user].present?
       params[:user].each do |user|
@@ -307,7 +272,7 @@ class PlansController < ApplicationController
     # list between create and update. Also, you can specialize this method
     # with per-user checking of permissible attributes.
     def plan_params
-      params.require(:plan).permit(:name, :event_type, :owner, :alcohol, :event_type_id, :permitter_id, :workflow_state, :owner_id, :post_event_name, :post_event_email, :post_event_phone, :responsibility, :cpr, :communication, :event_contact, users_attributes: [:id, :email, :password, :address, :roles, :roles_mask, :phone_number], event_types_attributes: [:id, :name, :description], permitters_attributes: [:id, :name, :address, :phone_number], user_attributes: [:id, :email, :password, :address, :roles, :roles_mask, :phone_number], :user_ids => [], operation_periods_attributes: [:id, :attendance, first_aid_stations_attributes: [:name, :level, :md, :rn, :emt, :aed, :provider_id, :contact_name, :contact_phone, :id, :location], transports_attributes: [:id, :name, :level, :provider_id, :contact_name, :contact_phone, :location], mobile_teams_attributes: [:id, :name, :level, :aed, :provider_id, :contact_name, :contact_phone, :location], dispatchs_attributes: [:id, :name, :level, :provider_id, :contact_name, :contact_phone, :location]])
+      params.require(:plan).permit(:name, :event_type, :owner, :alcohol, :event_type_id, :permitter_id, :workflow_state, :owner_id, :post_event_name, :post_event_email, :post_event_phone, :responsibility, :cpr, :communication, :event_contact, users_attributes: [:id, :email, :password, :address, :roles, :roles_mask, :phone_number], event_types_attributes: [:id, :name, :description], permitters_attributes: [:id, :name, :address, :phone_number], user_attributes: [:id, :email, :password, :address, :roles, :roles_mask, :phone_number], :user_ids => [], operation_periods_attributes: [:id, :attendance, :start_date, :end_date, first_aid_stations_attributes: [:name, :level, :md, :rn, :emt, :aed, :provider_id, :contact_name, :contact_phone, :id, :location], transports_attributes: [:id, :name, :level, :provider_id, :contact_name, :contact_phone, :location], mobile_teams_attributes: [:id, :name, :level, :aed, :provider_id, :contact_name, :contact_phone, :location], dispatchs_attributes: [:id, :name, :level, :provider_id, :contact_name, :contact_phone, :location]])
     end
 
     def operation_periods_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+
+  def form_builder_for(obj)
+    simple_form_for obj do |f|
+      return f
+    end
+  end
+  
 end

--- a/app/models/operation_period.rb
+++ b/app/models/operation_period.rb
@@ -27,20 +27,22 @@ class OperationPeriod < ActiveRecord::Base
   validates :end_date, presence: true
   
   DEFAULT_DATETIME_FORMAT = "%m/%d/%Y %H:%M %p"
-  
-  def start_date=(new_start_date)
-    if new_start_date =~ /[0-9]{2}\/[0-9]{2}\/[0-9]{4}/
-      super(DateTime.strptime(new_start_date, DEFAULT_DATETIME_FORMAT))
-    else
-      super
-    end
+
+  def start_date=(new_end_date)
+    super parse_date_time_if_in_preferred_format(new_end_date)
   end
 
   def end_date=(new_end_date)
-    if new_end_date =~ /[0-9]{2}\/[0-9]{2}\/[0-9]{4}/
-      super(DateTime.strptime(new_end_date, DEFAULT_DATETIME_FORMAT))
+    super parse_date_time_if_in_preferred_format(new_end_date)
+  end
+
+  private
+
+  def parse_date_time_if_in_preferred_format(date_time)
+    if date_time =~ /[0-9]{2}\/[0-9]{2}\/[0-9]{4}/
+      DateTime.strptime(date_time, DEFAULT_DATETIME_FORMAT)
     else
-      super
+      date_time
     end
   end
   

--- a/app/models/operation_period.rb
+++ b/app/models/operation_period.rb
@@ -23,4 +23,25 @@ class OperationPeriod < ActiveRecord::Base
 
   accepts_nested_attributes_for :first_aid_stations, :mobile_teams, :transports, :dispatchs
 
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  
+  DEFAULT_DATETIME_FORMAT = "%m/%d/%Y %H:%M %p"
+  
+  def start_date=(new_start_date)
+    if new_start_date =~ /[0-9]{2}\/[0-9]{2}\/[0-9]{4}/
+      super(DateTime.strptime(new_start_date, DEFAULT_DATETIME_FORMAT))
+    else
+      super
+    end
+  end
+
+  def end_date=(new_end_date)
+    if new_end_date =~ /[0-9]{2}\/[0-9]{2}\/[0-9]{4}/
+      super(DateTime.strptime(new_end_date, DEFAULT_DATETIME_FORMAT))
+    else
+      super
+    end
+  end
+  
 end

--- a/app/views/plans/_first_aid_station.html.erb
+++ b/app/views/plans/_first_aid_station.html.erb
@@ -1,39 +1,12 @@
-<%= op.simple_fields_for "first_aid_stations[id][#{DateTime.now.to_i}]" do |f| %>
 <tr>
+
+  <% %w(name level md rn emt aed provider contact_name contact_phone).each do |attribute| %>
+  
   <td>
-    <span><%= first_aid_station[:name] %></span>
-    <%= f.input :name, required: false, as: :hidden, value: first_aid_station[:name] %>
+    <span><%= first_aid_station[attribute] %></span>
+    <%= hidden_field_tag "plan[operation_periods_attributes][#{operation_period_index}][first_aid_stations_attributes][#{first_aid_station_id}][#{attribute}]", first_aid_station[attribute] %>
   </td>
-  <td>
-    <span><%= first_aid_station[:level] %></span>
-    <%= f.input :level, required: false, as: :hidden, value: first_aid_station[:level] %>
-  </td>
-  <td>
-    <span><%= first_aid_station[:md] %></span>
-    <%= f.input :md, required: false, as: :hidden, value: first_aid_station[:md] %>
-  </td>
-  <td>
-    <span><%= first_aid_station[:rn] %></span>
-    <%= f.input :rn, required: false, as: :hidden, value: first_aid_station[:rn] %>
-  </td>
-  <td>
-    <span><%= first_aid_station[:emt] %></span>
-    <%= f.input :emt, required: false, as: :hidden, value: first_aid_station[:emt] %>
-  </td>
-  <td>
-    <span><%= first_aid_station[:aed] %></span>
-    <%= f.input :aed, required: false, as: :hidden, value: first_aid_station[:aed] %>
-  </td>
-  <td>
-    <span><%= first_aid_station[:provider] %></span>
-    <%= f.input :provider, required: false, as: :hidden, value: first_aid_station[:provider] %>
-  </td>
-  <td>
-    <span><%= first_aid_station[:contact_name] %></span>
-    <%= f.input :contact_name, required: false, as: :hidden, value: first_aid_station[:contact_name] %>
-  </td>
-  <td>
-    <span><%= first_aid_station[:contact_phone] %></span>
-    <%= f.input :contact_phone, required: false, as: :hidden, value: first_aid_station[:contact_phone] %>
-  </td>
-<% end %>
+
+  <% end %>
+
+</tr>

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -94,7 +94,7 @@
         <li class="tab-title active"><a href="#panel1">Operational Period 1</a></li>
       </ul>
       <div class="tabs-content">
-        <%= render 'operation_period', count: 1 %>
+        <%= render partial: 'operation_period', locals: { plan_form: f, count: 1 } %>
       </div>
 
     <div class="row">

--- a/app/views/plans/_new_first_aid_station.html.erb
+++ b/app/views/plans/_new_first_aid_station.html.erb
@@ -29,7 +29,7 @@
     <% end %>
   </div>
   <div class="modal-footer">
-    <%= link_to "Add First Aid Station", update_first_aid_station_path(operation), id: "new-first-aid-station-submit", class: "button primary save-modal disabled", method: :post, remote: true %>
+    <%= link_to "Add First Aid Station", update_first_aid_station_path(operation, operation_period_index: operation_period_index), id: "new-first-aid-station-submit", class: "button primary save-modal disabled", method: :post, remote: true %>
   </div>
   <script>
     $(document).ready(function(){

--- a/app/views/plans/_operation_period.html.erb
+++ b/app/views/plans/_operation_period.html.erb
@@ -1,4 +1,4 @@
-<%= simple_fields_for "operation_periods[id][#{count}]" do |op| %>
+<%= plan_form.simple_fields_for :operation_periods do |op| %>
   <% if count == 1 %>
     <div class="content active" id="panel<%= count %>">
   <% else %>
@@ -9,7 +9,7 @@
       <%= op.label :start_date, class: "inline", label: "START" %>
       </div>
       <div class="small-4 columns end">
-        <%= op.input_field :start_date, label: false, placeholder: "Date", class: "dateSelect" %>
+        <%= op.input_field :start_date, label: false, placeholder: "Date", as: "string", class: "dateSelect" %>
       </div>
     </div>
     <div class="row">
@@ -17,7 +17,7 @@
       <%= op.label :end_date, class: "inline", label: "END" %>
       </div>
       <div class="small-4 columns end">
-        <%= op.input_field :end_date, label: false, placeholder: "Date", class: "dateSelect" %>
+        <%= op.input_field :end_date, label: false, placeholder: "Date", as: "string", class: "dateSelect" %>
       </div>
     </div>        
     <div class="row">
@@ -48,7 +48,7 @@
           </tbody>
         </table> 
             <a id="new_first_aid_station" class="button primary tiny radius" href="#" data-reveal-id="new-first-aid-station"><i class="fi-plus"></i>&nbsp;ADD FIRST AID STATION</a>
-            <%= render 'new_first_aid_station', :operation => "operation_periods[id][#{count}]" %>
+            <%= render partial: 'new_first_aid_station', :locals => { :operation => "operation_periods[id][#{count}]", :operation_period_index => count - 1 } %>
     </fieldset>
     <fieldset>
       <legend>MOBILE TEAMS</legend>

--- a/app/views/plans/add_first_aid_station.js.erb
+++ b/app/views/plans/add_first_aid_station.js.erb
@@ -1,4 +1,4 @@
 <%= simple_fields_for @operation_period do |op| %>
-  $("tbody", "#first_aid_table").append("<%= j render(partial: 'first_aid_station', locals: {op: op, first_aid_station: @first_aid_station} )%>")
+  $("tbody", "#first_aid_table").append("<%= j render(partial: 'first_aid_station', locals: {op: op, operation_period_index: @operation_period_index, first_aid_station_id: DateTime.now.to_i, first_aid_station: @first_aid_station} ) %>")
 <% end %>
 $('#new-first-aid-station').foundation('reveal','close');

--- a/app/views/plans/add_operation_period.js.erb
+++ b/app/views/plans/add_operation_period.js.erb
@@ -1,4 +1,7 @@
-$(".tabs-content").append("<%= j render(partial: 'operation_period', locals: { count: @count } )%>")
+<% plan_form = form_builder_for(@plan) %>
+<% 1.upto(@count - 1).map { |c| render(partial: 'operation_period', locals: { plan_form: plan_form, count: c } ) } %>
+
+$(".tabs-content").append("<%= j render(partial: 'operation_period', locals: { plan_form: plan_form, count: @count } )%>")
 $(".tabs").append('<li class="tab-title"><a href="#panel<%= @count %>">Operational Period <%= @count %></a></li>')
 $(".add_operation_period_button").html('<%= link_to add_operation_period_path(@count), remote: true, class: "button primary tiny radius right", id: "new_operation_period"  do %><i class="fi-plus"></i> ADD OPERATIONAL PERIOD<% end %>')
 $('.dateSelect').fdatetimepicker({

--- a/app/views/plans/update_first_aid_station.js.erb
+++ b/app/views/plans/update_first_aid_station.js.erb
@@ -28,6 +28,6 @@ if (firstAidStation) {
       'first_aid_station': firstAidStation
     },
     type: 'post',
-    url: '<%= j add_first_aid_station_path(@operation_period) %>'
+    url: '<%= j add_first_aid_station_path(@operation_period, operation_period_index: @operation_period_index) %>'
   });
 }

--- a/spec/acceptance/plans_spec.rb
+++ b/spec/acceptance/plans_spec.rb
@@ -43,8 +43,8 @@ feature "Plan" do
       count = Plan.all.count
       visit "/plans/new"
       fill_in 'plan_name', with: "test plan"
-      fill_in 'operation_periods_id_1_start_date', with: "01/01/2020 08:00 am"
-      fill_in  'operation_periods_id_1_end_date', with: "01/03/2020 08:00 pm"
+      fill_in 'plan_operation_periods_attributes_0_start_date', with: "01/01/2020 08:00 am"
+      fill_in 'plan_operation_periods_attributes_0_end_date', with: "01/03/2020 08:00 pm"
       click_button 'SUBMIT PLAN'
       expect(Plan.all.count).to eq count +1 
     end
@@ -55,10 +55,10 @@ feature "Plan" do
       count = Plan.all.count
       visit "/plans/new"
       fill_in 'plan_name', with: "test plan"
-      fill_in 'operation_periods_id_1_start_date', with: "01/01/2020 08:00 am"
-      fill_in  'operation_periods_id_1_end_date', with: "01/03/2020 08:00 pm"
+      fill_in 'plan_operation_periods_attributes_0_start_date', with: "01/01/2020 08:00 am"
+      fill_in 'plan_operation_periods_attributes_0_end_date', with: "01/03/2020 08:00 pm"
       click_link 'new_first_aid_station'
-      within '.operation_periods_id_first_aid_stations_id_name' do
+      within '.plan_operation_periods_id_first_aid_stations_id_name' do
         fill_in 'input', with: "test"
       end
       click_button 'SUBMIT PLAN'

--- a/spec/models/operation_period_spec.rb
+++ b/spec/models/operation_period_spec.rb
@@ -13,6 +13,37 @@
 
 require 'rails_helper'
 
-RSpec.describe OperationPeriod, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe OperationPeriod do
+
+  let(:operation_period) { FactoryGirl.create(:operation_period) }
+  
+  context "#start_date=" do
+
+    it "understands the m/d/Y H:M %p format" do
+      operation_period.update(start_date: "06/24/1985 09:42 am")
+      expect(operation_period.start_date).to eq DateTime.new(1985, 6, 24, 9, 42)
+    end
+
+    it "supports setting to nil" do
+      operation_period.update(start_date: nil)
+      expect(operation_period.start_date).to be_nil
+    end
+    
+  end
+
+  context "#end_date=" do
+
+    it "understands the m/d/Y H:M %p format" do
+      operation_period.update(end_date: "06/24/1985 09:42 am")
+      expect(operation_period.end_date).to eq DateTime.new(1985, 6, 24, 9, 42)
+    end
+
+    it "supports setting to nil" do
+      operation_period.update(end_date: nil)
+      expect(operation_period.end_date).to be_nil
+    end
+    
+  end
+
+  
 end


### PR DESCRIPTION
Replaces most PlansController#update with a call to Plan.create.

Changes the forms for OperationPeriod and FirstAidStation so that they send the correct attribute names.

Fixes #27.
