### PR TITLE
Deleting assets

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -78,25 +78,25 @@ class PlansController < ApplicationController
       @operation_period = @plan.operation_periods.find(op[1][:id])
       if op[1][:first_aid_stations_attributes].present? 
         op[1][:first_aid_stations_attributes].each do |first_aid|
-          @first_aid_update = FirstAidStation.find(first_aid[1][:id]).update_attributes(first_aid[1])
+          @first_aid_update = FirstAidStation.find(first_aid[1][:id]).update_attributes(first_aid[1].except("_destroy"))
         end
       end
 
       if op[1][:mobile_teams_attributes].present? 
         op[1][:mobile_teams_attributes].each do |mobile|
-          @mobile_team_update = MobileTeam.find(mobile[1][:id]).update_attributes(mobile[1])
+          @mobile_team_update = MobileTeam.find(mobile[1][:id]).update_attributes(mobile[1].except("_destroy"))
         end
       end
 
       if op[1][:transports_attributes].present? 
         op[1][:transports_attributes].each do |transport|
-          @transport_team_update = Transport.find(transport[1][:id]).update_attributes(transport[1])
+          @transport_team_update = Transport.find(transport[1][:id]).update_attributes(transport[1].except("_destroy"))
         end
       end
 
       if op[1][:dispatchs_attributes].present? 
         op[1][:dispatchs_attributes].each do |dispatch|
-          @dispatch_team_update = Dispatch.find(dispatch[1][:id]).update_attributes(dispatch[1])
+          @dispatch_team_update = Dispatch.find(dispatch[1][:id]).update_attributes(dispatch[1].except("_destroy"))
         end
       end
 
@@ -335,7 +335,8 @@ class PlansController < ApplicationController
                                                                              :contact_name,
                                                                              :contact_phone,
                                                                              :id,
-                                                                             :location
+                                                                             :location,
+                                                                             :_destroy
                                                                             ],
                                              transports_attributes: [
                                                                      :id,
@@ -344,7 +345,8 @@ class PlansController < ApplicationController
                                                                      :provider_id,
                                                                      :contact_name,
                                                                      :contact_phone,
-                                                                     :location
+                                                                     :location,
+                                                                     :_destroy
                                                                     ],
                                              mobile_teams_attributes: [
                                                                        :id,
@@ -354,7 +356,8 @@ class PlansController < ApplicationController
                                                                        :provider_id,
                                                                        :contact_name,
                                                                        :contact_phone,
-                                                                       :location
+                                                                       :location,
+                                                                       :_destroy
                                                                       ],
                                              dispatchs_attributes: [
                                                                     :id,
@@ -363,7 +366,8 @@ class PlansController < ApplicationController
                                                                     :provider_id,
                                                                     :contact_name,
                                                                     :contact_phone,
-                                                                    :location
+                                                                    :location,
+                                                                    :_destroy
                                                                    ]
                                             ]
               )

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -267,15 +267,167 @@ class PlansController < ApplicationController
 
   private 
 
-   # Using a private method to encapsulate the permissible parameters is
-    # just a good pattern since you'll be able to reuse the same permit
-    # list between create and update. Also, you can specialize this method
-    # with per-user checking of permissible attributes.
-    def plan_params
-      params.require(:plan).permit(:name, :event_type, :owner, :alcohol, :event_type_id, :permitter_id, :workflow_state, :owner_id, :post_event_name, :post_event_email, :post_event_phone, :responsibility, :cpr, :communication, :event_contact, users_attributes: [:id, :email, :password, :address, :roles, :roles_mask, :phone_number], event_types_attributes: [:id, :name, :description], permitters_attributes: [:id, :name, :address, :phone_number], user_attributes: [:id, :email, :password, :address, :roles, :roles_mask, :phone_number], :user_ids => [], operation_periods_attributes: [:id, :attendance, :start_date, :end_date, first_aid_stations_attributes: [:name, :level, :md, :rn, :emt, :aed, :provider_id, :contact_name, :contact_phone, :id, :location], transports_attributes: [:id, :name, :level, :provider_id, :contact_name, :contact_phone, :location], mobile_teams_attributes: [:id, :name, :level, :aed, :provider_id, :contact_name, :contact_phone, :location], dispatchs_attributes: [:id, :name, :level, :provider_id, :contact_name, :contact_phone, :location]])
-    end
-
-    def operation_periods_params
-      params.require(:operation_periods).permit(id:[:start_date, :end_date, :attendance, :plan_id, first_aid_stations: [id:[:name, :level, :md, :rn, :emt, :aed, :provider_id, :contact_name, :contact_phone, :location, :id, :lat, :lng]], transport: [id: [:name, :level, :provider_id, :contact_name, :contact_phone, :location, :lat, :lng]], mobile_teams: [id: [:name, :level, :aed, :provider_id, :contact_name, :contact_phone, :location, :lat, :lng]], dispatch: [id: [:name, :level, :provider_id, :contact_name, :contact_phone, :location]]])
+  # Using a private method to encapsulate the permissible parameters is
+  # just a good pattern since you'll be able to reuse the same permit
+  # list between create and update. Also, you can specialize this method
+  # with per-user checking of permissible attributes.
+  def plan_params
+    params
+      .require(:plan)
+      .permit(:name,
+              :event_type,
+              :owner,
+              :alcohol,
+              :event_type_id,
+              :permitter_id,
+              :workflow_state,
+              :owner_id,
+              :post_event_name,
+              :post_event_email,
+              :post_event_phone,
+              :responsibility,
+              :cpr,
+              :communication,
+              :event_contact,
+              users_attributes: [
+                                 :id,
+                                 :email,
+                                 :password,
+                                 :address,
+                                 :roles,
+                                 :roles_mask,
+                                 :phone_number
+                                ],
+              event_types_attributes: [
+                                       :id,
+                                       :name,
+                                       :description
+                                      ],
+              permitters_attributes: [
+                                      :id,
+                                      :name,
+                                      :address,
+                                      :phone_number
+                                     ],
+              user_attributes: [
+                                :id,
+                                :email,
+                                :password,
+                                :address,
+                                :roles,
+                                :roles_mask,
+                                :phone_number
+                               ],
+              :user_ids => [ ],
+              operation_periods_attributes: [
+                                             :id,
+                                             :attendance,
+                                             :start_date,
+                                             :end_date,
+                                             first_aid_stations_attributes: [
+                                                                             :name,
+                                                                             :level,
+                                                                             :md,
+                                                                             :rn,
+                                                                             :emt,
+                                                                             :aed,
+                                                                             :provider_id,
+                                                                             :contact_name,
+                                                                             :contact_phone,
+                                                                             :id,
+                                                                             :location
+                                                                            ],
+                                             transports_attributes: [
+                                                                     :id,
+                                                                     :name,
+                                                                     :level,
+                                                                     :provider_id,
+                                                                     :contact_name,
+                                                                     :contact_phone,
+                                                                     :location
+                                                                    ],
+                                             mobile_teams_attributes: [
+                                                                       :id,
+                                                                       :name,
+                                                                       :level,
+                                                                       :aed,
+                                                                       :provider_id,
+                                                                       :contact_name,
+                                                                       :contact_phone,
+                                                                       :location
+                                                                      ],
+                                             dispatchs_attributes: [
+                                                                    :id,
+                                                                    :name,
+                                                                    :level,
+                                                                    :provider_id,
+                                                                    :contact_name,
+                                                                    :contact_phone,
+                                                                    :location
+                                                                   ]
+                                            ]
+              )
+  end
+  
+  def operation_periods_params
+    params.require(:operation_periods).permit(id:
+                                              [
+                                               :start_date,
+                                               :end_date,
+                                               :attendance,
+                                               :plan_id,
+                                               first_aid_stations: [
+                                                                    id:[
+                                                                        :name,
+                                                                        :level,
+                                                                        :md,
+                                                                        :rn,
+                                                                        :emt,
+                                                                        :aed,
+                                                                        :provider_id,
+                                                                        :contact_name,
+                                                                        :contact_phone,
+                                                                        :location,
+                                                                        :id,
+                                                                        :lat,
+                                                                        :lng
+                                                                       ]
+                                                                   ],
+                                               transport: [
+                                                           id: [
+                                                                :name,
+                                                                :level,
+                                                                :provider_id,
+                                                                :contact_name,
+                                                                :contact_phone,
+                                                                :location,
+                                                                :lat,
+                                                                :lng
+                                                               ]
+                                                          ],
+                                               mobile_teams: [
+                                                              id: [
+                                                                   :name,
+                                                                   :level,
+                                                                   :aed,
+                                                                   :provider_id,
+                                                                   :contact_name,
+                                                                   :contact_phone,
+                                                                   :location,
+                                                                   :lat,
+                                                                   :lng
+                                                                  ]
+                                                             ],
+                                               dispatch: [
+                                                          id: [
+                                                               :name,
+                                                               :level,
+                                                               :provider_id,
+                                                               :contact_name,
+                                                               :contact_phone,
+                                                               :location
+                                                              ]
+                                                         ]
+                                              ])
     end
 end

--- a/app/models/operation_period.rb
+++ b/app/models/operation_period.rb
@@ -21,7 +21,7 @@ class OperationPeriod < ActiveRecord::Base
   has_many :dispatchs
   belongs_to :plan
 
-  accepts_nested_attributes_for :first_aid_stations, :mobile_teams, :transports, :dispatchs
+  accepts_nested_attributes_for :first_aid_stations, :mobile_teams, :transports, :dispatchs, allow_destroy: true
 
   validates :start_date, presence: true
   validates :end_date, presence: true

--- a/app/views/plans/_dispatch_show.html.erb
+++ b/app/views/plans/_dispatch_show.html.erb
@@ -10,5 +10,6 @@
                     label: "Provider", required: false, label: false %></td>
   <td><%= f.input :contact_name, required: false, label: false %></td>
   <td><%= f.input :contact_phone, required: false, label: false %></td>
+  <td><%= f.input :_destroy, as: :boolean, label: "Remove" %></td>
 </tr>
 <% end %>

--- a/app/views/plans/_first_aid_stations_show.html.erb
+++ b/app/views/plans/_first_aid_stations_show.html.erb
@@ -16,5 +16,7 @@
                     label: "Provider", required: false, label: false %></td>
   <td><%= f.input :contact_name, required: false, label: false %></td>
   <td><%= f.input :contact_phone, required: false, label: false %></td>
+  <td><%= f.input :_destroy, as: :boolean, label: "Remove" %></td>
 </tr>
 <% end %>
+

--- a/app/views/plans/_mobile_team_show.html.erb
+++ b/app/views/plans/_mobile_team_show.html.erb
@@ -14,5 +14,6 @@
                     label: "Provider", required: false, label: false %></td>
   <td><%= f.input :contact_name, required: false, label: false %></td>
   <td><%= f.input :contact_phone, required: false, label: false %></td>
+  <td><%= f.input :_destroy, as: :boolean, label: "Remove" %></td>
 </tr>
 <% end %>

--- a/app/views/plans/_transport_show.html.erb
+++ b/app/views/plans/_transport_show.html.erb
@@ -11,5 +11,6 @@
                     label: "Provider", required: false, label: false %></td>
   <td><%= f.input :contact_name, required: false, label: false %></td>
   <td><%= f.input :contact_phone, required: false, label: false %></td>
+  <td><%= f.input :_destroy, as: :boolean, label: "Remove" %></td>
 </tr>
 <% end %>

--- a/spec/acceptance/plans_spec.rb
+++ b/spec/acceptance/plans_spec.rb
@@ -34,8 +34,6 @@ feature "Plan" do
       visit "/plans"
       expect(page).to have_content "#{plan.name}"
     end
-
-    
   end
 
   context "create a new plan" do
@@ -73,25 +71,41 @@ feature "Plan" do
     let(:plan) { FactoryGirl.create(:plan) }
     let(:operation_period) { FactoryGirl.create(:operation_period) }
     let(:first_aid_station) { FactoryGirl.create(:first_aid_station) }
+    let(:mobile_team) { FactoryGirl.create(:mobile_team) }
+    let(:transport) { FactoryGirl.create(:transport) }
+    let(:dispatch) { FactoryGirl.create(:dispatch) }
 
     before do
       plan.operation_periods << operation_period
       operation_period.first_aid_stations << first_aid_station
+      operation_period.mobile_teams << mobile_team
+      operation_period.transports << transport
+      operation_period.dispatchs << dispatch
     end
 
-    scenario "admin can delete a first aid station", js: true do
-
-      sign_in(admin)
-      visit "/plans/#{plan.id}"
-
-      expect(page).to have_selector("input[value='#{first_aid_station.name}']")
-
-      check "Destroy"
-      click_on "SAVE DRAFT"
+    %w(first_aid_station mobile_team transport dispatch).each do |asset_type|
       
-      expect(page).to_not have_selector("input[value='#{first_aid_station.name}']")
+      scenario "admin can delete a #{asset_type.humanize.downcase}", js: true do
+
+        sign_in(admin)
+        visit "/plans/#{plan.id}"
+
+        asset = send(asset_type)
+        asset_selector = "input[value='#{asset.name}']"
+        
+        expect(page).to have_selector(asset_selector)
+
+        asset_row = find(asset_selector).find(:xpath, "../../..")
+
+        within(asset_row) {
+          check "Remove"
+        }
+        
+        click_on "SAVE DRAFT"
+
+        expect(page).to_not have_selector(asset_selector)
+      end
     end
-    
   end
 
 end

--- a/spec/acceptance/plans_spec.rb
+++ b/spec/acceptance/plans_spec.rb
@@ -34,6 +34,8 @@ feature "Plan" do
       visit "/plans"
       expect(page).to have_content "#{plan.name}"
     end
+
+    
   end
 
   context "create a new plan" do
@@ -65,4 +67,31 @@ feature "Plan" do
       expect(Plan.all.count).to eq count +1 
     end
   end
+
+  context "deleting medical assets" do
+
+    let(:plan) { FactoryGirl.create(:plan) }
+    let(:operation_period) { FactoryGirl.create(:operation_period) }
+    let(:first_aid_station) { FactoryGirl.create(:first_aid_station) }
+
+    before do
+      plan.operation_periods << operation_period
+      operation_period.first_aid_stations << first_aid_station
+    end
+
+    scenario "admin can delete a first aid station", js: true do
+
+      sign_in(admin)
+      visit "/plans/#{plan.id}"
+
+      expect(page).to have_selector("input[value='#{first_aid_station.name}']")
+
+      check "Destroy"
+      click_on "SAVE DRAFT"
+      
+      expect(page).to_not have_selector("input[value='#{first_aid_station.name}']")
+    end
+    
+  end
+
 end

--- a/spec/acceptance/plans_spec.rb
+++ b/spec/acceptance/plans_spec.rb
@@ -38,31 +38,35 @@ feature "Plan" do
 
   context "create a new plan" do
 
-    scenario "admin can create a basic plan" do
+    before do
       sign_in(admin)
       count = Plan.all.count
       visit "/plans/new"
       fill_in 'plan_name', with: "test plan"
       fill_in 'plan_operation_periods_attributes_0_start_date', with: "01/01/2020 08:00 am"
       fill_in 'plan_operation_periods_attributes_0_end_date', with: "01/03/2020 08:00 pm"
-      click_button 'SUBMIT PLAN'
-      expect(Plan.all.count).to eq count +1 
+    end
+    
+    scenario "admin can create a basic plan" do
+      expect{ 
+        click_button 'SUBMIT PLAN'
+      }.to change { Plan.count }.by(1)
     end
 
-    scenario "admin can create a plan with medical assets", js: true  do
-      pending
-      sign_in(admin)
-      count = Plan.all.count
-      visit "/plans/new"
-      fill_in 'plan_name', with: "test plan"
-      fill_in 'plan_operation_periods_attributes_0_start_date', with: "01/01/2020 08:00 am"
-      fill_in 'plan_operation_periods_attributes_0_end_date', with: "01/03/2020 08:00 pm"
+    scenario "admin can create a plan with a first aid station", js: true  do
       click_link 'new_first_aid_station'
-      within '.plan_operation_periods_id_first_aid_stations_id_name' do
-        fill_in 'input', with: "test"
+
+      first_aid_station_name = "2nd Aid Station"
+      within '.first_aid_stations_id_name' do
+        fill_in 'Name', with: first_aid_station_name
       end
-      click_button 'SUBMIT PLAN'
-      expect(Plan.all.count).to eq count +1 
+
+      click_on "new-first-aid-station-submit"
+      expect(page).to have_content first_aid_station_name
+
+      expect { 
+        click_button 'SUBMIT PLAN'
+      }.to change{ FirstAidStation.count }.by(1)
     end
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -18,6 +18,21 @@ FactoryGirl.define do
     operation_periods = FactoryGirl.create(:operation_period)
   end
 
+  factory :first_aid_station do
+    name Faker::Lorem.words(3).join(" ")
+  end
+
+  factory :mobile_team do
+    name Faker::Lorem.words(3).join(" ")
+  end
+
+  factory :transport do
+    name Faker::Lorem.words(3).join(" ")
+  end
+
+  factory :dispatch do
+    name Faker::Lorem.words(3).join(" ")
+  end
 
   factory :admin, :class => User do |u|
     u.email { Faker::Internet.email }


### PR DESCRIPTION
Adds the ability to delete existing medical assets on the plan page.

Removing an asset is done by checking the "Remove" checkbox on the relevant asset fiend and saving the plan.

Fixes #22.
