### PR TITLE
Show Permitting Agency Contact Info

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -49,4 +49,14 @@ $(function() {
   $(document).on('opened.fndtn.reveal', '#new-first-aid-station[data-reveal]', function () {
     console.log("open!!")
   });
+
+  var updatePermitterContactInfo = function() {
+    var activePermitterId = $("#plan_permitter_id").val();
+    $(".permitter").hide();
+    $("[data-permitter-id=" + activePermitterId + "]").show();
+  };
+
+  $("body").on("change", "#plan_permitter_id", updatePermitterContactInfo);
+
+  updatePermitterContactInfo();
 });

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -514,12 +514,6 @@ input[type="checkbox"]{
   }
 }
 
-
-
-
-
-
-
-
-
-
+.hidden {
+  display: none;
+}

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -35,6 +35,8 @@ class PlansController < ApplicationController
   def show
     @plan = Plan.all.includes(:operation_periods).where(id: params[:id]).first
     @count = 0
+    @permitters = Permitter.order("name ASC")
+    
     if @plan.accepted?
       render 'plans/show_accepted'
     else
@@ -45,6 +47,7 @@ class PlansController < ApplicationController
   def new
     @plan = Plan.new
     @plan.operation_periods.build
+    @permitters = Permitter.order("name ASC")
     
     respond_to do |format|
       format.html

--- a/app/views/permitters/_permitter.html.erb
+++ b/app/views/permitters/_permitter.html.erb
@@ -1,0 +1,8 @@
+<div class="permitter hidden" data-permitter-id="<%= permitter.id %>">
+  <%= simple_format permitter.address, class: "address" %>
+  <p class="phone-number">
+    <i class="fi-telephone"></i>
+    <%= permitter.phone_number %>
+  </p>
+</div>
+

--- a/app/views/plans/_edit_form.html.erb
+++ b/app/views/plans/_edit_form.html.erb
@@ -101,11 +101,12 @@
         </div>
         <div class="small-5 columns">
         <%= f.association :permitter,
-                          collection: Permitter.all,
+                          collection: @permitters,
                           label_method: :name,
                           value_method: :id,
                           include_blank: false,
                           label: false %>
+        <%= render partial: "permitters/permitter", collection: @permitters %>
         </div>
         <div class="large-4 columns end">
             <%= render 'comment_form', plan: @plan, title: "permitter" %>

--- a/app/views/plans/_form.html.erb
+++ b/app/views/plans/_form.html.erb
@@ -65,11 +65,12 @@
         </div>
         <div class="small-5 columns end">
         <%= f.association :permitter,
-                            collection: Permitter.all,
+                            collection: @permitters,
                             label_method: :name,
                             value_method: :id,
                             include_blank: false,
                             label: false %>
+        <%= render partial: "permitters/permitter", collection: @permitters %>
         </div>
         <div class="large-3 columns end">
         </div>

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -14,7 +14,7 @@ FactoryGirl.define do
   end
 
   factory :plan do
-    name Faker::Lorem.word
+    name { Faker::Lorem.words(3).join }
     operation_periods = FactoryGirl.create(:operation_period)
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -18,6 +18,11 @@ FactoryGirl.define do
     operation_periods = FactoryGirl.create(:operation_period)
   end
 
+  factory :permitter do
+    name { Faker::Lorem.words(3).join(" ") }
+    phone_number { Faker::PhoneNumber.phone_number }
+    address { [ Faker::Address.street_address, Faker::Address.city, Faker::Address.zip, Faker::Address.state ].join("\n") }
+  end
 
   factory :admin, :class => User do |u|
     u.email { Faker::Internet.email }


### PR DESCRIPTION
Shows permitting agency contact info below the select box. Fixes #26.

Renders everything as hidden elements and shows the correct one on page load and changes to the select box.

If the number of possible permitting agencies is expected to be large, we may need to consider an AJAX call to render the information.
