### PR TITLE
Inviting collaborators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "cocoon"
 gem 'compass'
 gem "compass-rails", github: "Compass/compass-rails", branch: "master"
 gem 'devise'
+gem 'email_validator'
 gem 'figaro'
 gem 'font-awesome-sass-rails'
 gem 'foundation-datetimepicker-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
     email_spec (1.6.0)
       launchy (~> 2.1)
       mail (~> 2.2)
+    email_validator (1.6.0)
+      activemodel
     erubis (2.7.0)
     eventmachine (1.0.7)
     execjs (2.5.2)
@@ -406,6 +408,7 @@ DEPENDENCIES
   database_cleaner
   devise
   email_spec
+  email_validator
   factory_girl_rails
   faker
   figaro
@@ -455,3 +458,6 @@ DEPENDENCIES
   unicorn
   unicorn-worker-killer
   workflow
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -73,10 +73,10 @@ $(function() {
   }
 
   $("body").on("click", "#invite", function() {
-     var form = $(this).closest(".invitation-form");
-     var url = form.data().url;
-     var data = form.find(":input").serialize();
-     $.post(url, data);
+    var form = $(this).closest(".invitation-form");
+    var url = form.data().url;
+    var data = form.find(":input").serialize();
+    $.post(url, data);
   });
 
 });

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -71,4 +71,10 @@ $(function() {
   if (window.location.hash.indexOf("comment-") != -1) {
     $(window.location.hash).effect("highlight", {}, 5000);       
   }
+
+  $("body").on("click", "#invite", function() {
+     var url = $(this).closest(".invitation-form").data().url;
+     $.post(url, { email: $("#invitation-email").val() });
+  });
+
 });

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -73,8 +73,10 @@ $(function() {
   }
 
   $("body").on("click", "#invite", function() {
-     var url = $(this).closest(".invitation-form").data().url;
-     $.post(url, { email: $("#invitation-email").val() });
+     var form = $(this).closest(".invitation-form");
+     var url = form.data().url;
+     var data = form.find(":input").serialize();
+     $.post(url, data);
   });
 
 });

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -517,3 +517,7 @@ input[type="checkbox"]{
 .hidden {
   display: none;
 }
+
+.reveal-modal-bg {
+  position: fixed;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,8 @@ class HomeController < ApplicationController
   def index
     @plans = Plan.all
     @operation_period = OperationPeriod.all
+    @invitations = current_user.try(:invitations) || []
+    
     respond_to do |format|
       format.html
       format.json { render json: @plans }

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -3,8 +3,14 @@ class InvitationsController < ApplicationController
   def create
     @plan = Plan.find(params[:plan_id])
     authorize! :manage, @plan
-    @invitation = @plan.invitations.create(role: "edit", email: params[:email])
+    @invitation = @plan.invitations.create(invitation_params)
     @invitation.send_invitation_email!
+  end
+
+  private
+
+  def invitation_params
+    params.require(:invitation).permit(:email, :role)
   end
 
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -4,7 +4,9 @@ class InvitationsController < ApplicationController
     @plan = Plan.find(params[:plan_id])
     authorize! :manage, @plan
     @invitation = @plan.invitations.create(invitation_params)
-    @invitation.send_invitation_email!
+    if @invitation.valid?
+      @invitation.send_invitation_email!
+    end
   end
 
   private

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,0 +1,10 @@
+class InvitationsController < ApplicationController
+
+  def create
+    @plan = Plan.find(params[:plan_id])
+    authorize! :manage, @plan
+    @invitation = @plan.invitations.create(role: "edit", email: params[:email])
+    @invitation.send_invitation_email!
+  end
+
+end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -140,17 +140,18 @@ class PlansController < ApplicationController
         end
       end
 
-      if params[:user].present?
-        params[:user].each do |user|
-          @plan.users << User.where(email: user[1][:email]).first
-          p = PlanUser.where(plan_id: @plan.id, user_id: user).first
-          p.role = user[1][:role]
-          p.save
-        end
-      end
-
       @operation_period.save
     end
+
+    if params[:user].present?
+      params[:user].each do |user|
+        @plan.users << User.where(email: user[1][:email]).first
+        p = PlanUser.where(plan_id: @plan.id, user_id: user).first
+        p.role = user[1][:role]
+        p.save
+      end
+    end
+
     respond_to do |format|
       if @plan.update_attributes(plan_params)
         format.html { redirect_to @plan, notice: 'plan was successfully updated.' }

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -145,10 +145,8 @@ class PlansController < ApplicationController
 
     if params[:user].present?
       params[:user].each do |user|
-        @plan.users << User.where(email: user[1][:email]).first
-        p = PlanUser.where(plan_id: @plan.id, user_id: user).first
-        p.role = user[1][:role]
-        p.save
+        user_obj = User.find_by_email(user[1][:email])
+        @plan.plan_users.create(user: user_obj, role: user[1][:role])
       end
     end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -88,7 +88,7 @@ class PlansController < ApplicationController
 
   def update
     @plan = Plan.find(params[:id])
-    plan_params[:operation_periods_attributes].each do |op|
+    plan_params[:operation_periods_attributes].try(:each) do |op|
       @operation_period = @plan.operation_periods.find(op[1][:id])
       if op[1][:first_aid_stations_attributes].present? 
         op[1][:first_aid_stations_attributes].each do |first_aid|

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -5,7 +5,7 @@ class InvitationMailer < ActionMailer::Base
     @plan = options[:plan]
     @email = options[:email]
     mail(to: @email,
-         subject: "You have been invited to collaborate on a plan")
+         subject: "You have been invited to collaborate on the medical plan #{@plan.name}")
   end
 
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,9 @@
+class InvitationMailer < ActionMailer::Base
+  default from: "Senoia <senoia@senoia.com>"
+
+  def invite(options = { email: nil, plan: nil })
+    mail(to: options[:email],
+         subject: "You have been invited to collaborate on a plan")
+  end
+
+end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -2,7 +2,9 @@ class InvitationMailer < ActionMailer::Base
   default from: "Senoia <senoia@senoia.com>"
 
   def invite(options = { email: nil, plan: nil })
-    mail(to: options[:email],
+    @plan = options[:plan]
+    @email = options[:email]
+    mail(to: @email,
          subject: "You have been invited to collaborate on a plan")
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,8 @@ class Ability
     if user.has_role? :admin
       can :manage, :all
     else
-      can :manage, :plan, :creator_id => user.id
+      can :manage, Plan, :creator_id => user.id
+      can :manage, Plan, :plan_users => { role: "edit", user_id: user.id }
       can :read, :all
     end
   end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -5,9 +5,11 @@ class Invitation < ActiveRecord::Base
   validates :plan, presence: true
   validates :email, presence: true, email: true, uniqueness: { scope: :plan_id, message: "has already been invited" }
   validates :role, presence: true, inclusion: PlanUser::ROLES
+
+  scope :pending, -> { where(invited_user_id: nil) }
   
   def self.claim_invitations(user)
-    where(email: user.email, invited_user: nil).includes(:plan).each do |invitation|
+    pending.where(email: user.email).includes(:plan).each do |invitation|
       transaction do
         invitation.plan.plan_users.create(user: user, role: invitation.role)
         invitation.update(invited_user: user)

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,15 +1,16 @@
 class Invitation < ActiveRecord::Base
   belongs_to :plan, inverse_of: :invitations
+  belongs_to :invited_user, class_name: "User", inverse_of: :invitations
   
   validates :plan, presence: true
   validates :email, presence: true, email: true
   validates :role, presence: true, inclusion: PlanUser::ROLES
 
   def self.claim_invitations(user)
-    where(email: user.email).includes(:plan).each do |invitation|
+    where(email: user.email, invited_user: nil).includes(:plan).each do |invitation|
       transaction do
         invitation.plan.plan_users.create(user: user, role: invitation.role)
-        invitation.destroy
+        invitation.update(invited_user: user)
       end
     end
   end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -6,8 +6,8 @@ class Invitation < ActiveRecord::Base
   validates :role, presence: true, inclusion: PlanUser::ROLES
 
   def self.claim_invitations(user)
-    transaction do
-      where(email: user.email).each do |invitation|
+    where(email: user.email).each do |invitation|
+      transaction do
         invitation.plan.plan_users.create(user: user, role: invitation.role)
         invitation.destroy
       end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,12 +1,12 @@
 class Invitation < ActiveRecord::Base
-  belongs_to :plan
+  belongs_to :plan, inverse_of: :invitations
   
   validates :plan, presence: true
   validates :email, presence: true, email: true
   validates :role, presence: true, inclusion: PlanUser::ROLES
 
   def self.claim_invitations(user)
-    where(email: user.email).each do |invitation|
+    where(email: user.email).includes(:plan).each do |invitation|
       transaction do
         invitation.plan.plan_users.create(user: user, role: invitation.role)
         invitation.destroy

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -3,9 +3,9 @@ class Invitation < ActiveRecord::Base
   belongs_to :invited_user, class_name: "User", inverse_of: :invitations
   
   validates :plan, presence: true
-  validates :email, presence: true, email: true
+  validates :email, presence: true, email: true, uniqueness: { scope: :plan_id, message: "has already been invited" }
   validates :role, presence: true, inclusion: PlanUser::ROLES
-
+  
   def self.claim_invitations(user)
     where(email: user.email, invited_user: nil).includes(:plan).each do |invitation|
       transaction do

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,20 @@
+class Invitation < ActiveRecord::Base
+  belongs_to :plan
+  
+  validates :plan, presence: true
+  validates :email, presence: true
+  validates :role, presence: true, inclusion: PlanUser::ROLES
+
+  def self.claim_invitations(user)
+    transaction do
+      where(email: user.email).each do |invitation|
+        invitation.plan.plan_users.create(user: user, role: invitation.role)
+        invitation.destroy
+      end
+    end
+  end
+
+  def send_invitation_email!
+    InvitationMailer.invite(email: email, plan: plan).deliver_later
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,7 +2,7 @@ class Invitation < ActiveRecord::Base
   belongs_to :plan
   
   validates :plan, presence: true
-  validates :email, presence: true
+  validates :email, presence: true, email: true
   validates :role, presence: true, inclusion: PlanUser::ROLES
 
   def self.claim_invitations(user)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -35,7 +35,7 @@ class Plan < ActiveRecord::Base
 
   has_many :operation_periods
   has_many :comments, as: :commentable
-  has_many :invitations
+  has_many :invitations, inverse_of: :plan, dependent: :destroy
 
   accepts_nested_attributes_for :event_type, :operation_periods, :owner
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -35,6 +35,7 @@ class Plan < ActiveRecord::Base
 
   has_many :operation_periods
   has_many :comments, as: :commentable
+  has_many :invitations
 
   accepts_nested_attributes_for :event_type, :operation_periods, :owner
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -31,6 +31,8 @@ class Plan < ActiveRecord::Base
   belongs_to :permitter
   has_many :plan_users
   has_many :users, through: :plan_users
+  has_many :users_who_can_edit, -> { where(plan_users: { role: "edit" }) }, through: :plan_users, source: :user
+  has_many :users_who_can_view, -> { where(plan_users: { role: "view" }) }, through: :plan_users, source: :user
   belongs_to :creator, class_name: User
 
   has_many :operation_periods

--- a/app/models/plan_user.rb
+++ b/app/models/plan_user.rb
@@ -11,4 +11,10 @@
 class PlanUser < ActiveRecord::Base
   belongs_to :user
   belongs_to :plan
+
+  ROLES = %w(view edit)
+
+  validates :user, presence: true
+  validates :plan, presence: true
+  validates :role, presence: true, inclusion: ROLES
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ActiveRecord::Base
   # :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, 
          :recoverable, 
+         :registerable,
          :rememberable, 
          :trackable, 
          :validatable, 
@@ -49,6 +50,10 @@ class User < ActiveRecord::Base
   # roles later, always append them at the end!
   roles :admin, :user, :guest, :provider, :promoter, :staff
 
+  after_create do
+    Invitation.claim_invitations(self)
+  end
+  
   def to_s
     if [ first_name, last_name ].any?(&:blank?)
       email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,7 @@ class User < ActiveRecord::Base
          :validatable, 
          :confirmable
 
+  has_many :invitations, foreign_key: :invited_user_id, inverse_of: :invited_user
   has_many :plans
   has_many :plan_users
 

--- a/app/views/application/_error.html.erb
+++ b/app/views/application/_error.html.erb
@@ -1,0 +1,3 @@
+<small class="error">
+  <%= error %>.
+</small>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,8 +7,8 @@
       <%= f.error_notification %>
 
       <div class="form-inputs">
-        <%= f.input :email, required: true, autofocus: true %>
-        <%= f.input :password, required: true %>
+        <%= f.input :email, required: true, autofocus: !params[:email].present?, input_html: { value: params[:email] } %>
+        <%= f.input :password, required: true, autofocus: params[:email].present? %>
         <%= f.input :password_confirmation, required: true %>
       </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,6 +2,11 @@
   <div id="homepage-hero">
   <div class="row">
     <div class="large-12 columns pageTitle">
+      <% @invitations.each do |invitation| %>
+        <div data-alert class="alert-box info radius">
+          You were invited to collaborate on the plan <%= link_to invitation.plan.name, invitation.plan %>.
+        </div>
+      <% end %>
     </div>  
     <div class="large-4 columns">
       <%= link_to new_plan_path do %>

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,0 +1,3 @@
+
+<%= link_to "Sign up", new_user_registration_url %>
+

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,3 +1,10 @@
+<p>
+  You have been invited to collaborate on the medical plan <%= @plan %>.
+</p>
 
-<%= link_to "Sign up", new_user_registration_url %>
+<p>
+  Please sign up through the link below to view the plan.
+</p>
+
+<%= link_to "Sign up", new_user_registration_url(email: @email) %>
 

--- a/app/views/invitation_mailer/invite.html.haml
+++ b/app/views/invitation_mailer/invite.html.haml
@@ -1,3 +1,0 @@
-
-<%= link_to "Sign up", new_user_registration_url %>
-

--- a/app/views/invitation_mailer/invite.html.haml
+++ b/app/views/invitation_mailer/invite.html.haml
@@ -1,0 +1,3 @@
+
+<%= link_to "Sign up", new_user_registration_url %>
+

--- a/app/views/invitations/_form.html.erb
+++ b/app/views/invitations/_form.html.erb
@@ -1,0 +1,5 @@
+<div class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
+  <input type="email" id="invitation-email" name="invitation[email]">
+  <%= select_tag "invitation[role]", options_for_select([ "view", "edit" ]) %>
+  <%= link_to "Invite", "javascript:void(0);", id: "invite", class: "button primary" %>
+</div>

--- a/app/views/invitations/_form.html.erb
+++ b/app/views/invitations/_form.html.erb
@@ -9,7 +9,7 @@
         <%= select_tag "invitation[role]", options_for_select([ [ "Can View", "view" ], [ "Can Edit", "edit" ] ]) %>
       </div>
       <div class="large-2 columns">
-        <%= link_to "Invite", "javascript:void(0);", id: "invite", class: "button tiny radius", style: "margin-left: 1em" %>
+        <%= link_to "Invite", "javascript:void(0);", id: "invite", class: "button tiny radius", style: "margin-left: 1em; margin-top: 0.1em" %>
       </div>
     </div>
   </td>

--- a/app/views/invitations/_form.html.erb
+++ b/app/views/invitations/_form.html.erb
@@ -1,5 +1,16 @@
-<div class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
-  <input type="email" id="invitation-email" name="invitation[email]">
-  <%= select_tag "invitation[role]", options_for_select([ [ "Can View", "view" ], [ "Can Edit", "edit" ] ]) %>
-  <%= link_to "Invite", "javascript:void(0);", id: "invite", class: "button primary" %>
-</div>
+<tr>
+  <td colspan="3" class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
+    <h4>Invite by email:</h4>
+    <div class="row large-collapse">
+      <div class="large-7 columns">
+        <input type="email" id="invitation-email" name="invitation[email]" placeholder="Email address">
+      </div>
+      <div class="large-3 columns">
+        <%= select_tag "invitation[role]", options_for_select([ [ "Can View", "view" ], [ "Can Edit", "edit" ] ]) %>
+      </div>
+      <div class="large-2 columns">
+        <%= link_to "Invite", "javascript:void(0);", id: "invite", class: "button tiny radius", style: "margin-left: 1em" %>
+      </div>
+    </div>
+  </td>
+</tr>

--- a/app/views/invitations/_form.html.erb
+++ b/app/views/invitations/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
   <input type="email" id="invitation-email" name="invitation[email]">
-  <%= select_tag "invitation[role]", options_for_select([ "view", "edit" ]) %>
+  <%= select_tag "invitation[role]", options_for_select([ [ "Can View", "view" ], [ "Can Edit", "edit" ] ]) %>
   <%= link_to "Invite", "javascript:void(0);", id: "invite", class: "button primary" %>
 </div>

--- a/app/views/invitations/_invitation.html.erb
+++ b/app/views/invitations/_invitation.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <td><%= invitation.email %></td>
+  <td><%= { "view" => "Can View", "edit" => "Can Edit" }[invitation.role] %></td>
+  <td style="font-size: 80%">
+    Invitation sent.
+  </td>
+</tr>

--- a/app/views/invitations/create.js.erb
+++ b/app/views/invitations/create.js.erb
@@ -1,0 +1,1 @@
+$(".invitation-form").html("Invite sent")

--- a/app/views/invitations/create.js.erb
+++ b/app/views/invitations/create.js.erb
@@ -1,2 +1,16 @@
-$(".invitation-form").closest("tr").before("<%= j render @invitation %>")
-$("#invitation-email").val("")
+<% if @invitation.valid? %>
+
+  $(".invitation-form").closest("tr").before("<%= j render @invitation %>");
+  $("#invitation-email").val("");
+  $(".invitation-form").find(".error").remove();
+
+<% else %>
+
+  $(".invitation-form").find(".error").remove();
+
+  <% @invitation.errors.keys.each do |field| %>
+    var field = $("[name='invitation[<%= j field.to_s %>]']");
+    field.after("<%= j render partial: "application/error", locals: { error: @invitation.errors.full_messages_for(field).first } %>");
+  <% end %>
+
+<% end %>

--- a/app/views/invitations/create.js.erb
+++ b/app/views/invitations/create.js.erb
@@ -1,1 +1,2 @@
-$(".invitation-form").html("Invite sent")
+$(".invitation-form").closest("tr").before("<%= j render @invitation %>")
+$("#invitation-email").val("")

--- a/app/views/layouts/invitation_mailer.html.erb
+++ b/app/views/layouts/invitation_mailer.html.erb
@@ -1,0 +1,1 @@
+<%= render template: "layouts/notification_mailer" %>

--- a/app/views/plans/_new_plan_user.html.erb
+++ b/app/views/plans/_new_plan_user.html.erb
@@ -16,7 +16,7 @@
           <td><%= check_box "plan_edit[id]", user.id, {:class => 'table-row-checkbox user_edit'}, user.id %></td>
         </tr>
       <% end %>
-      <%= render @plan.invitations %>
+      <%= render @plan.invitations.pending %>
       <% if @plan.persisted? && can?(:manage, @plan) %>
         <%= render partial: "invitations/form" %>
       <% end %>      

--- a/app/views/plans/_new_plan_user.html.erb
+++ b/app/views/plans/_new_plan_user.html.erb
@@ -30,10 +30,13 @@
       </tbody>
     </table>
   </div>
-  <div class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
-    <input type="email" id="invitation-email" name="collaborator[email]">
-    <%= link_to "Invite", "javascript:void(0);", id: "invite" %>
-  </div>
+
+  <% if @plan.persisted? %>
+    <div class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
+      <input type="email" id="invitation-email" name="collaborator[email]">
+      <%= link_to "Invite", "javascript:void(0);", id: "invite" %>
+    </div>
+  <% end %>
   <div class="modal-footer">
     <%= link_to "Add Collaborator", update_user_plan_path, id: "new-plan-user-submit", class: "button primary save-modal", remote: true, method: :post %>
   </div>

--- a/app/views/plans/_new_plan_user.html.erb
+++ b/app/views/plans/_new_plan_user.html.erb
@@ -16,24 +16,14 @@
           <td><%= check_box "plan_edit[id]", user.id, {:class => 'table-row-checkbox user_edit'}, user.id %></td>
         </tr>
       <% end %>
-      <% if can? :edit, User %>
-        <tr>
-          <td></td>
-          <td></td>
-          <td>
-            <%= link_to new_user_path do %>
-              <i class="fi-plus"></i>&nbsp;Add New User
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
+      <%= render @plan.invitations %>
+      <% if @plan.persisted? && can?(:manage, @plan) %>
+        <%= render partial: "invitations/form" %>
+      <% end %>      
       </tbody>
     </table>
-  </div>
 
-  <% if @plan.persisted? && can?(:manage, @plan) %>
-    <%= render partial: "invitations/form" %>
-  <% end %>
+  </div>
   
   <div class="modal-footer">
     <%= link_to "Add Collaborator", update_user_plan_path, id: "new-plan-user-submit", class: "button primary save-modal", remote: true, method: :post %>

--- a/app/views/plans/_new_plan_user.html.erb
+++ b/app/views/plans/_new_plan_user.html.erb
@@ -31,12 +31,10 @@
     </table>
   </div>
 
-  <% if @plan.persisted? %>
-    <div class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
-      <input type="email" id="invitation-email" name="collaborator[email]">
-      <%= link_to "Invite", "javascript:void(0);", id: "invite" %>
-    </div>
+  <% if @plan.persisted? && can?(:manage, @plan) %>
+    <%= render partial: "invitations/form" %>
   <% end %>
+  
   <div class="modal-footer">
     <%= link_to "Add Collaborator", update_user_plan_path, id: "new-plan-user-submit", class: "button primary save-modal", remote: true, method: :post %>
   </div>

--- a/app/views/plans/_new_plan_user.html.erb
+++ b/app/views/plans/_new_plan_user.html.erb
@@ -30,6 +30,10 @@
       </tbody>
     </table>
   </div>
+  <div class="invitation-form" data-url="<%= url_for([ @plan, :invitations]) %>">
+    <input type="email" id="invitation-email" name="collaborator[email]">
+    <%= link_to "Invite", "javascript:void(0);", id: "invite" %>
+  </div>
   <div class="modal-footer">
     <%= link_to "Add Collaborator", update_user_plan_path, id: "new-plan-user-submit", class: "button primary save-modal", remote: true, method: :post %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       delete 'remove_user(/:plan_id/:user_id)', :to => 'plans#remove_user', :as => :remove_user
     end
     resources :comments, only: :create
+    resources :invitations, only: :create
   end
   resources :comments do
     resources :replies, only: :create

--- a/db/migrate/20150831142604_create_invitations.rb
+++ b/db/migrate/20150831142604_create_invitations.rb
@@ -1,0 +1,11 @@
+class CreateInvitations < ActiveRecord::Migration
+  def change
+    create_table :invitations do |t|
+      t.integer :plan_id
+      t.text :email
+      t.string :role
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150831142604_create_invitations.rb
+++ b/db/migrate/20150831142604_create_invitations.rb
@@ -4,6 +4,7 @@ class CreateInvitations < ActiveRecord::Migration
       t.integer :plan_id
       t.text :email
       t.string :role
+      t.integer :invited_user_id
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -88,8 +88,9 @@ ActiveRecord::Schema.define(version: 20150831142604) do
     t.integer  "plan_id"
     t.text     "email"
     t.string   "role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "invited_user_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   create_table "medical_assets", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150710182104) do
+ActiveRecord::Schema.define(version: 20150831142604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,14 @@ ActiveRecord::Schema.define(version: 20150710182104) do
     t.integer "first_aid_staion_id"
     t.integer "user_id"
     t.boolean "contact"
+  end
+
+  create_table "invitations", force: :cascade do |t|
+    t.integer  "plan_id"
+    t.text     "email"
+    t.string   "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "medical_assets", force: :cascade do |t|

--- a/spec/acceptance/collaborators_spec.rb
+++ b/spec/acceptance/collaborators_spec.rb
@@ -18,11 +18,11 @@ feature "Collaborators" do
 
     scenario "adds a collaborator" do
       click_on "ADD USERS"
+      sleep 0.5 #FIXME Race condition with modal
       
       find("#plan_view_id_#{@user.id}").set(true)
       find("#new-plan-user-submit").click
 
-      #FIXME This fails sometimes due to a race condition
       expect(page).to have_css("input[value='#{@user.email}']") 
       
       click_on "SAVE DRAFT"
@@ -42,7 +42,7 @@ feature "Collaborators" do
 
     scenario "cannot invite a collaborator without an email" do
       click_on "ADD USERS"
-      sleep 1
+      sleep 0.5 #FIXME Race condition with modal
       find("#invitation-email").set("not an email")
       click_on "Invite"
       expect(page).to have_content("Email is invalid")
@@ -52,7 +52,7 @@ feature "Collaborators" do
 
       click_on "ADD USERS"
 
-      sleep 1
+      sleep 0.5 #FIXME Race condition with modal
       find("#invitation-email").set(invite_email_address)
       click_on "Invite"
 

--- a/spec/acceptance/collaborators_spec.rb
+++ b/spec/acceptance/collaborators_spec.rb
@@ -84,7 +84,7 @@ feature "Collaborators" do
         click_on "Login"
       end
 
-      visit "/plans/#{plan.id}"
+      click_link plan.name
       expect(find("fieldset", text: "COLLABORATORS")).to have_content(invite_email_address)
     end
   end

--- a/spec/acceptance/collaborators_spec.rb
+++ b/spec/acceptance/collaborators_spec.rb
@@ -4,12 +4,14 @@ feature "Collaborators" do
 
   let(:admin) { FactoryGirl.create(:admin) }
   let(:plan) { FactoryGirl.create(:plan, workflow_state: "awaiting_review") }
+  let(:invite_email_address) { Faker::Internet.email }
 
   context "Admin", js: true do
     
     background do
       @collaborator = plan.plan_users.create(user: FactoryGirl.create(:user), role: "view").user
       @user = FactoryGirl.create(:user)
+
       sign_in(admin)
       visit "/plans/#{plan.id}"
     end
@@ -37,7 +39,46 @@ feature "Collaborators" do
 
       expect(find("fieldset", text: "COLLABORATORS")).to_not have_content(@collaborator.email)
     end
-    
+
+    scenario "invites a collaborator" do
+
+      click_on "ADD USERS"
+
+      sleep 1
+      find("#invitation-email").set(invite_email_address)
+      click_on "Invite"
+
+      expect(page).to have_content("Invite sent")
+      sign_out
+
+      open_email(invite_email_address)
+      click_email_link_matching(/sign_up/)
+
+      reset_mailer
+
+      password = Faker::Internet.password
+      fill_in "Email", with: invite_email_address
+      fill_in "user_password", with: password
+      fill_in "user_password_confirmation", with: password
+      click_on "Sign Up"
+
+      expect(page).to have_content("confirmation link")
+
+      open_email(invite_email_address)
+      click_email_link_matching(/confirm/)
+
+      visit "/users/sign_in"
+
+      fill_in "Email", with: invite_email_address
+      fill_in "Password", with: password
+
+      within ".form-actions" do
+        click_on "Login"
+      end
+
+      visit "/plans/#{plan.id}"
+      expect(find("fieldset", text: "COLLABORATORS")).to have_content(invite_email_address)
+    end
   end
 
 end

--- a/spec/acceptance/collaborators_spec.rb
+++ b/spec/acceptance/collaborators_spec.rb
@@ -40,6 +40,14 @@ feature "Collaborators" do
       expect(find("fieldset", text: "COLLABORATORS")).to_not have_content(@collaborator.email)
     end
 
+    scenario "cannot invite a collaborator without an email" do
+      click_on "ADD USERS"
+      sleep 1
+      find("#invitation-email").set("not an email")
+      click_on "Invite"
+      expect(page).to have_content("Email is invalid")
+    end
+
     scenario "invites a collaborator" do
 
       click_on "ADD USERS"

--- a/spec/acceptance/collaborators_spec.rb
+++ b/spec/acceptance/collaborators_spec.rb
@@ -48,7 +48,7 @@ feature "Collaborators" do
       find("#invitation-email").set(invite_email_address)
       click_on "Invite"
 
-      expect(page).to have_content("Invite sent")
+      expect(page).to have_content("Invitation sent")
       sign_out
 
       open_email(invite_email_address)

--- a/spec/acceptance/collaborators_spec.rb
+++ b/spec/acceptance/collaborators_spec.rb
@@ -20,7 +20,8 @@ feature "Collaborators" do
       find("#plan_view_id_#{@user.id}").set(true)
       find("#new-plan-user-submit").click
 
-      expect(page).to have_css("input[value='#{@user.email}']")
+      #FIXME This fails sometimes due to a race condition
+      expect(page).to have_css("input[value='#{@user.email}']") 
       
       click_on "SAVE DRAFT"
 

--- a/spec/acceptance/collaborators_spec.rb
+++ b/spec/acceptance/collaborators_spec.rb
@@ -1,0 +1,42 @@
+require_relative "acceptance_helper"
+
+feature "Collaborators" do
+
+  let(:admin) { FactoryGirl.create(:admin) }
+  let(:plan) { FactoryGirl.create(:plan, workflow_state: "awaiting_review") }
+
+  context "Admin", js: true do
+    
+    background do
+      @collaborator = plan.plan_users.create(user: FactoryGirl.create(:user), role: "view").user
+      @user = FactoryGirl.create(:user)
+      sign_in(admin)
+      visit "/plans/#{plan.id}"
+    end
+
+    scenario "adds a collaborator" do
+      click_on "ADD USERS"
+      
+      find("#plan_view_id_#{@user.id}").set(true)
+      find("#new-plan-user-submit").click
+
+      expect(page).to have_css("input[value='#{@user.email}']")
+      
+      click_on "SAVE DRAFT"
+
+      expect(find("fieldset", text: "COLLABORATORS")).to have_content(@user.email)
+    end
+
+    scenario "removes a collaborator" do
+      within find("fieldset", text: "COLLABORATORS") do
+        within find("tr", text: @collaborator.email) do
+          click_on "Remove"
+        end
+      end
+
+      expect(find("fieldset", text: "COLLABORATORS")).to_not have_content(@collaborator.email)
+    end
+    
+  end
+
+end

--- a/spec/acceptance/support/helpers.rb
+++ b/spec/acceptance/support/helpers.rb
@@ -6,8 +6,8 @@ module HelperMethods
     click_button "Login"
   end
 
-  def sign_out(user)
-    visit "/admin/users"
+  def sign_out
+    visit "/"
     click_link "Logout"
   end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CommentsController do
 
       it "sends notifications" do
 
-        plan.users << notification_recipient
+        plan.users_who_can_view << notification_recipient
         
         expect(NotificationMailer).to receive(:new_comment_notification)
           .with({ recipient: notification_recipient, comment: kind_of(Comment) })

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe RepliesController do
       
       it "sends notifications" do
 
-        comment.commentable.users << notification_recipient
+        comment.commentable.users_who_can_view << notification_recipient
         
         expect(NotificationMailer).to receive(:new_comment_notification)
           .with({ recipient: notification_recipient, comment: kind_of(Comment) })

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Invitation, type: :model do
 
   describe "#claim_invitations" do
+    pending
   end
   
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Invitation, type: :model do
 
   describe "#claim_invitations" do
-    
   end
   
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Invitation, type: :model do
+
+  describe "#claim_invitations" do
+    
+  end
+  
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require "factory_girl"
+require "action_mailer"
 require 'email_spec'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Enables users to invite new collaborators to plans.

Invitees get an email notification asking them to sign up. Once they've done that and confirmed their email address, they're granted a role on the plan in question.

Fixes #12.
