### PR TITLE
Plan index fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require jquery-ui
 //= require foundation
 //= require foundation-datetimepicker
+//= require foundation-datepicker
 //= require main
 //= require turbolinks
 //= require smart_listing

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,8 +1,12 @@
 $(function() {
-  $('.dateSelect').fdatetimepicker({
+  $('.dateTimeSelect').fdatetimepicker({
     format: 'mm/dd/yyyy H:ii p'
   }); 
 
+  $('.dateSelect').fdatepicker({
+		format: 'mm/dd/yyyy'
+	});
+  
   $('#all_plans tbody tr').css('cursor', 'pointer')
   $('#all_plans tbody tr').click(function() {
     window.location = $('a', $(this)).attr('href')

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
  *
  *= require_self
  *= require foundation_and_overrides
+ *= require foundation-datepicker
  *= require main
 
  */

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -6,7 +6,7 @@ class PlansController < ApplicationController
   helper_method :view_own_plans?
   
   def index
-    plans_scope = Plan.includes(:operation_periods, :event_type)
+    plans_scope = Plan.includes(:operation_periods, :event_type).calculating_total_attendance
 
     if view_own_plans?
       plans_scope = plans_scope.affiliated_to(current_user) 
@@ -19,7 +19,7 @@ class PlansController < ApplicationController
     @plans = smart_listing_create(:plans,
                                   plans_scope,
                                   partial: 'plans/listing',
-                                  default_sort: { created_at: "desc" })
+                                  default_sort: { "plans.created_at" => "desc" })
     respond_to do |format|
       format.js
       format.html

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -79,10 +79,6 @@ class Plan < ActiveRecord::Base
     send_notifications_on_reject
   end
 
-  def self.a(number)
-    Plan.all.collect { |a| a.operation_periods.where("attendance >= ?", number) }.flatten 
-  end
-
   def start_date
     operation_periods.map(&:start_date).compact.min
   end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -61,7 +61,7 @@ class Plan < ActiveRecord::Base
   }
   
   scope :with_outstanding_comments, -> { joins(:comment_threads).where(comments: { open: true, parent_id: nil }).uniq }
-  scope :affiliated_to, -> (user) { where("owner_id = ? OR creator_id = ? OR id IN(?)", user.id, user.id, user.collaborated_plans.select(:id)) }
+  scope :affiliated_to, -> (user) { where("owner_id = ? OR creator_id = ? OR plans.id IN(?)", user.id, user.id, user.collaborated_plans.select(:id)) }
   
   include Workflow
   workflow do

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -43,19 +43,6 @@ class Plan < ActiveRecord::Base
 
   validates :name, presence: true
   validates :event_type, presence: true
-
-  scope :like, ->(search) { where("plans.name ilike ?", '%' + search + '%') }
-  scope :alcohol, -> { where("alcohol = ?", true) }
-  scope :owner, -> (search) { where("creator_id = ?", search) }
-
-  scope :event_type, lambda { |*args| 
-    event_type = args[0][:event_type]
-    if event_type.empty?
-      Plan.all
-    else
-      Plan.where("event_type_id = ?", event_type)
-    end
-  }
   
   scope :with_outstanding_comments, -> { joins(:comment_threads).where(comments: { open: true, parent_id: nil }).uniq }
   
@@ -121,7 +108,18 @@ class Plan < ActiveRecord::Base
     included do
       scope :affiliated_to, -> (user) { where("owner_id = ? OR creator_id = ? OR plans.id IN(?)", user.id, user.id, user.collaborated_plans.select(:id)) }
       scope :calculating_total_attendance, -> { joins("LEFT JOIN (SELECT plan_id, SUM(attendance) AS total_attendance FROM operation_periods GROUP BY plan_id) ta ON ta.plan_id = plans.id")}
+      scope :like, ->(search) { where("plans.name ilike ?", '%' + search + '%') }
+      scope :alcohol, -> { where("alcohol = ?", true) }
+      scope :owner, -> (search) { where("creator_id = ?", search) }
 
+      scope :event_type, lambda { |*args| 
+        event_type = args[0][:event_type]
+        if event_type.empty?
+          Plan.all
+        else
+          Plan.where("event_type_id = ?", event_type)
+        end
+      }
     end
 
     class_methods do

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -144,17 +144,31 @@ class Plan < ActiveRecord::Base
         if options[:attendance]
           scope = scope.filter_by_attendance(options[:attendance])
         end
-        
-        scope = scope.event_type(event_type: options[:event_type]) if options[:event_type]
+
+        if options[:event_type]
+          scope = scope.filter_by_event_type(options[:event_type])
+        end
+
         scope
       end
 
-      def filter_by_state(options)
-        query_fragments = options.select { |state, selected| selected == "1" }.map do |state, _|
-          sanitize_sql([ "workflow_state = ?", state ])
+      def filter_by_event_type(options)
+        event_type_ids = options.map{ |id, selected| id if selected == "1" }.compact
+        if event_type_ids.any?
+          where(event_type_id: event_type_ids)
+        else
+          all
         end
+      end
 
-        where(query_fragments.join(" OR "))
+      def filter_by_state(options)
+        selected_states = options.map { |state, selected| state if selected == "1" }.compact
+
+        if selected_states.any?
+          where(workflow_state: selected_states)
+        else
+          all
+        end
       end
 
       ATTENDANCE_FILTERS = {

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -44,7 +44,7 @@ class Plan < ActiveRecord::Base
   validates :name, presence: true
   validates :event_type, presence: true
 
-  scope :like, ->(search) { where("name ilike ?", '%' + search + '%') }
+  scope :like, ->(search) { where("plans.name ilike ?", '%' + search + '%') }
   scope :alcohol, -> { where("alcohol = ?", true) }
   scope :owner, -> (search) { where("creator_id = ?", search) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,11 +41,13 @@ class User < ActiveRecord::Base
          :validatable, 
          :confirmable
 
+  has_many :collaborated_plans, through: :plan_users, source: :plan
+  has_many :created_plans, class_name: "Plan", foreign_key: :creator_id
   has_many :invitations, foreign_key: :invited_user_id, inverse_of: :invited_user
-  has_many :plans
-  has_many :plan_users
   has_many :notifications,  -> { order("created_at DESC") }, inverse_of: :owner, foreign_key: :owner_id
-
+  has_many :owned_plans, class_name: "Plan", foreign_key: :owner_id
+  has_many :plan_users
+  
   roles_attribute :roles_mask
 
   # declare the valid roles -- do not change the order if you add more
@@ -63,4 +65,9 @@ class User < ActiveRecord::Base
       [ first_name, last_name ].join(" ")
     end
   end
+
+  def affiliated_plans
+    Plan.affiliated_to(self)
+  end
+
 end

--- a/app/views/clones/create.js.erb
+++ b/app/views/clones/create.js.erb
@@ -2,7 +2,7 @@
 
 $(".tabs-content").append("<%= j render(partial: 'operation_periods/operation_period', locals: { f: plan_form, operation_period: @clone, count: @count } )%>")
 $(".tabs").append('<li class="tab-title"><a href="#panel<%= @count %>">Operational Period <%= @count %></a></li>')
-$('.dateSelect').fdatetimepicker({
+$('.dateTimeSelect').fdatetimepicker({
     format: 'mm/dd/yyyy H:ii p'
   });
 $(".tab-title:last a").trigger("click");

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,6 @@
     <script src='//google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js' type='text/javascript'></script>
   </head>
 
-
   <body class="main" data-no-turbolink>
     <%= render 'shared/mainnav' %>
     <%= render 'shared/messages'  %>

--- a/app/views/operation_periods/_operation_period.html.erb
+++ b/app/views/operation_periods/_operation_period.html.erb
@@ -20,7 +20,7 @@
         <%= op.label :start_date, class: "inline", label: "START" %>
       </div>
       <div class="small-4 columns">
-        <%= op.input_field :start_date, label: false, placeholder: "Date", as: "string", class: "dateSelect", value: l(op.object.start_date).squeeze(" ") %>
+        <%= op.input_field :start_date, label: false, placeholder: "Date", as: "string", class: "dateTimeSelect", value: l(op.object.start_date).squeeze(" ") %>
       </div>
       <div class="large-4 columns">
         <%= render 'plans/comment_form', plan: @plan, title: "#{op.object.id}_start_date" %>

--- a/app/views/operation_periods/create.js.erb
+++ b/app/views/operation_periods/create.js.erb
@@ -2,7 +2,7 @@
 
 $(".tabs-content").html("<%= j render(partial: 'operation_periods/operation_period', locals: { f: f, operation_period: @operation_period, count: @count } )%>")
 $(".tabs .active").replaceWith('<li class="tab-title"><a href="#panel<%= @count %>">Operational Period <%= @count %></a></li>')
-$('.dateSelect').fdatetimepicker({
+$('.dateTimeSelect').fdatetimepicker({
     format: 'mm/dd/yyyy H:ii p'
   });
 $(".tab-title:last a").trigger("click");

--- a/app/views/operation_periods/new.js.erb
+++ b/app/views/operation_periods/new.js.erb
@@ -3,7 +3,7 @@
 
 $(".tabs-content").append("<%= j render(partial: 'plans/operation_period', locals: { plan_form: plan_form, count: @count } )%>")
 $(".tabs").append('<li class="tab-title"><a href="#panel<%= @count %>">Operational Period <%= @count %></a></li>')
-$('.dateSelect').fdatetimepicker({
+$('.dateTimeSelect').fdatetimepicker({
     format: 'mm/dd/yyyy H:ii p'
   });
 $(".tab-title:last a").trigger("click");

--- a/app/views/plans/_listing.html.erb
+++ b/app/views/plans/_listing.html.erb
@@ -2,27 +2,19 @@
   <table id="all_plans" class="plan_table large-12 columns">
     <thead>
       <th width="75"><%= smart_listing.sortable "Name", "name" %></th>
-      <th width="100"><%= smart_listing.sortable "Event Type", "event_type" %></th>
-      <th width="75"><%= smart_listing.sortable "Attendance", "attendance" %></th>
+      <th width="100"><%= smart_listing.sortable "Event Type", "event_types.name" %></th>
+      <th width="75"><%= smart_listing.sortable "Attendance", "operation_periods.attendance" %></th>
       <th width="75">Start Date</th>
       <th width="75">End Date</th>
     </thead>
     <tbody>
       <% smart_listing.collection.each do |o| %>
-        <% attendance = 0 %>
-        <% if o.operation_periods.present? %>
-          <% start_date = o.operation_periods.sort_by(&:start_date).first.start_date %>
-          <% end_date = o.operation_periods.sort_by(&:end_date).last.end_date %>
-          <% o.operation_periods.sort_by(&:start_date).each do |op| %>
-            <% op.attendance.present? ? attendance += op.attendance : nil %>
-          <% end %>
-        <% end %>
       <tr>
         <td><%= link_to o.name, plan_path(o) %></td>
         <td><%= o.event_type.nil? ? "N/A" : o.event_type.name %></td>
-        <td><%= attendance %></td>
-        <td><%= start_date.present? ? start_date.strftime("%D %l:%M %P") : "No Date" %></td>
-        <td><%= end_date.present? ? end_date.strftime("%D %l:%M %P") : "No Date" %></td>
+        <td><%= o.attendance if o.attendance > 0%></td>
+        <td><%= o.start_date.present? ? o.start_date.strftime("%D %l:%M %P") : "No Date" %></td>
+        <td><%= o.end_date.present? ? o.end_date.strftime("%D %l:%M %P") : "No Date" %></td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/plans/_listing.html.erb
+++ b/app/views/plans/_listing.html.erb
@@ -6,15 +6,21 @@
       <th width="75"><%= smart_listing.sortable "Attendance", "total_attendance" %></th>
       <th width="75">Start Date</th>
       <th width="75">End Date</th>
+      <% if current_user.try(:is_admin?) %>
+        <th width="20">Status</th>
+      <% end %>
     </thead>
     <tbody>
       <% smart_listing.collection.each do |o| %>
       <tr>
-        <td><%= link_to o.name, plan_path(o) %></td>
+        <td class="name"><%= link_to o.name, plan_path(o) %></td>
         <td><%= o.event_type.nil? ? "N/A" : o.event_type.name %></td>
-        <td><%= o.attendance if o.attendance > 0%></td>
+        <td class="attendance"><%= o.attendance if o.attendance > 0%></td>
         <td><%= o.start_date.present? ? o.start_date.strftime("%D %l:%M %P") : "No Date" %></td>
         <td><%= o.end_date.present? ? o.end_date.strftime("%D %l:%M %P") : "No Date" %></td>
+        <% if current_user.try(:is_admin?) %>
+          <td><%= t(o.workflow_state, scope: "plans.state") %></td>
+        <% end %>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/plans/_listing.html.erb
+++ b/app/views/plans/_listing.html.erb
@@ -3,7 +3,7 @@
     <thead>
       <th width="75"><%= smart_listing.sortable "Name", "name" %></th>
       <th width="100"><%= smart_listing.sortable "Event Type", "event_types.name" %></th>
-      <th width="75"><%= smart_listing.sortable "Attendance", "operation_periods.attendance" %></th>
+      <th width="75"><%= smart_listing.sortable "Attendance", "total_attendance" %></th>
       <th width="75">Start Date</th>
       <th width="75">End Date</th>
     </thead>

--- a/app/views/plans/_operation_period.html.erb
+++ b/app/views/plans/_operation_period.html.erb
@@ -5,7 +5,7 @@
       <%= op.label :start_date, class: "inline", label: "START" %>
       </div>
       <div class="small-4 columns end">
-        <%= op.input_field :start_date, label: false, placeholder: "Date", as: "string", class: "dateSelect" %>
+        <%= op.input_field :start_date, label: false, placeholder: "Date", as: "string", class: "dateTimeSelect" %>
       </div>
     </div>
     <div class="row">
@@ -13,7 +13,7 @@
       <%= op.label :end_date, class: "inline", label: "END" %>
       </div>
       <div class="small-4 columns end">
-        <%= op.input_field :end_date, label: false, placeholder: "Date", as: "string", class: "dateSelect" %>
+        <%= op.input_field :end_date, label: false, placeholder: "Date", as: "string", class: "dateTimeSelect" %>
       </div>
     </div>        
     <div class="row">

--- a/app/views/plans/add_operation_period.js.erb
+++ b/app/views/plans/add_operation_period.js.erb
@@ -4,7 +4,7 @@
 $(".tabs-content").append("<%= j render(partial: 'operation_period', locals: { plan_form: plan_form, count: @count } )%>")
 $(".tabs").append('<li class="tab-title"><a href="#panel<%= @count %>">Operational Period <%= @count %></a></li>')
 $(".add_operation_period_button").html('<%= link_to add_operation_period_path(@count), remote: true, class: "button primary tiny radius right", id: "new_operation_period"  do %><i class="fi-plus"></i> ADD OPERATIONAL PERIOD<% end %>')
-$('.dateSelect').fdatetimepicker({
+$('.dateTimeSelect').fdatetimepicker({
     format: 'mm/dd/yyyy H:ii p'
   });
 $(".tab-title:last a").trigger("click");

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -56,9 +56,9 @@
             <div class="checkbox inline">
               <% if can? :manage, Plan %>
                 <div>
-                  <%= hidden_field_tag "query[state][submitted]", "0", id: "draft" %>
+                  <%= hidden_field_tag "query[state][draft]", "0", id: "draft" %>
                   <label>
-                    <%= check_box_tag "query[state][submitted]" %>
+                    <%= check_box_tag "query[state][draft]" %>
                     <span class="submitted">Draft</span>
                   </label>
                 </div>
@@ -126,9 +126,9 @@
                   </label>
                 </div>
                 <div>
-                  <%= hidden_field_tag "query[attendance][500000]", "0", id: "500000" %>
+                  <%= hidden_field_tag "query[attendance][50000]", "0", id: "500000" %>
                   <label>
-                    <%= check_box_tag "query[attendance][500000]" %>
+                    <%= check_box_tag "query[attendance][50000]" %>
                     <span class="overdue">> 50,000</span>
                   </label>
                 </div>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -100,7 +100,15 @@
                 <h5>Event Type</h5>
                 <div class="row collapse">
                   <div class="medium-12 small-12 columns">
-                    <%= select_tag "query[event_type]", options_for_select(EventType.all.collect{ |d| [d.name, d.id] }), {prompt: "Event Type"}  %>
+                    <% EventType.order("name ASC").each do |event_type| %>
+                      <div>
+                        <%= hidden_field_tag "query[event_type][#{event_type.id}]", "0", id: "event_type_#{event_type.id}" %>
+                        <label>
+                          <%= check_box_tag "query[event_type][#{event_type.id}]" %>
+                          <span class="overdue"><%= event_type.name %></span>
+                        </label>
+                      </div>
+                    <% end %>
                   </div>
                 </div>
                 <h5>Attendance</h5>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -13,6 +13,20 @@
     <%= smart_listing_controls_for(:plans) do %>
       <!-- # Add search box to form - it submits the form automatically on text change -->
       <ul class="side-nav large-12 columns">
+        <li class="large-12 columns">
+          <div class="checkbox row collapse">
+            <div class="checkbox inline">
+              <div>
+                <%= hidden_field_tag :my_plans, "0", id: "mr" %>
+                <label>
+                  <%= check_box_tag :my_plans, "1", view_own_plans? %>
+                  <span><i class="fi-torso"></i>My Plans</span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </li>
+        <hr>
         <li class="large-12 columns request_search">
           <h4>SEARCH:</h4>
           <div class="row collapse">
@@ -37,17 +51,6 @@
           </div>
         </li>
         <li class="large-12 columns status_filter">
-          <div class="checkbox row collapse">
-            <div class="checkbox inline">
-              <div>
-                <%= hidden_field_tag :my_plans, "0", id: "mr" %>
-                <label>
-                  <%= check_box_tag :my_plans, "1", view_own_plans? %>
-                  <span><i class="fi-torso"></i>My Plans</span>
-                </label>
-              </div>
-            </div>
-          </div>
           <h5>Status</h5>
           <div class="checkbox row collapse">
             <div class="checkbox inline">

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -17,7 +17,7 @@
           <h4>SEARCH:</h4>
           <div class="row collapse">
             <div class="small-10 columns">
-              <%= text_field_tag :filter, '', placeholder: "I'd like to find...", autocomplete: :on %>
+              <%= text_field_tag "query[filter]", '', placeholder: "I'd like to find...", autocomplete: :on %>
             </div>
             <div class="small-2 columns">
               <button class="button postfix primary radius"><i class="fi-magnifying-glass"></i></button>
@@ -29,10 +29,10 @@
           <h5>Event Date</h5>
           <div class="row collapse">
             <div class="large-5 medium-5 small-5 columns">
-              <%= text_field_tag :start_date, '', placeholder: "start", class: 'dateSelect' %>
+              <%= text_field_tag "query[start_date]", '', placeholder: "start", class: 'dateSelect' %>
             </div>
             <div class="Large-5 large-offset-1 medium-5 medium-offset-1 small-5 small-offset-1 columns end">
-              <%= text_field_tag :end_date, '', placeholder: "end", class: 'dateSelect'  %>
+              <%= text_field_tag "query[end_date]", '', placeholder: "end", class: 'dateSelect'  %>
             </div>
           </div>
         </li>
@@ -40,9 +40,9 @@
           <div class="checkbox row collapse">
             <div class="checkbox inline">
               <div>
-                <%= hidden_field_tag :my_plans_check, "0", id: "mr" %>
+                <%= hidden_field_tag :my_plans, "0", id: "mr" %>
                 <label>
-                  <%= check_box_tag :my_plans_check %>
+                  <%= check_box_tag :my_plans, "1", view_own_plans? %>
                   <span><i class="fi-torso"></i>My Plans</span>
                 </label>
               </div>
@@ -53,30 +53,30 @@
             <div class="checkbox inline">
               <% if can? :manage, Plan %>
                 <div>
-                  <%= hidden_field_tag :submitted_check, "0", id: "draft" %>
+                  <%= hidden_field_tag "query[state][submitted]", "0", id: "draft" %>
                   <label>
-                    <%= check_box_tag :submitted_check %>
+                    <%= check_box_tag "query[state][submitted]" %>
                     <span class="submitted">Draft</span>
                   </label>
                 </div>
                 <div>
-                  <%= hidden_field_tag :awaiting_review_check, "0", id: "awaiting" %>
+                  <%= hidden_field_tag "query[state][awaiting_review]", "0", id: "awaiting" %>
                   <label>
-                    <%= check_box_tag :awaiting_review_check %>
+                    <%= check_box_tag "query[state][awaiting_review]" %>
                     <span>Under Review</span>
                   </label>
                 </div>
                 <div>
-                  <%= hidden_field_tag :reviewing_check, "0", id: "reviewing" %>
+                  <%= hidden_field_tag "query[state][being_reviewed]", "0", id: "reviewing" %>
                   <label>
-                    <%= check_box_tag :reviewing_check %>
+                    <%= check_box_tag "query[state][being_reviewed]" %>
                     <span class="overdue">Revision Requested</span>
                   </label>
                 </div>
                 <div>
-                  <%= hidden_field_tag :accepted_check, "0", id: "accepted" %>
+                  <%= hidden_field_tag "query[state][accepted]", "0", id: "accepted" %>
                   <label>
-                    <%= check_box_tag :accepted_check %>
+                    <%= check_box_tag "query[state][accepted]" %>
                     <span class="overdue">Approved</span>
                   </label>
                 </div>
@@ -88,44 +88,44 @@
               <% if can? :manage, Plan %>
                 <h5>Alcohol</h5>
                 <div>
-                  <%= hidden_field_tag :alcohol_check, "0", id: "alcohol" %>
+                  <%= hidden_field_tag "query[alcohol]", "0", id: "alcohol" %>
                   <label>
-                    <%= check_box_tag :alcohol_check %>
+                    <%= check_box_tag "query[alcohol]" %>
                     <span class="alcohol">Yes</span>
                   </label>
                 </div>
                 <h5>Event Type</h5>
                 <div class="row collapse">
                   <div class="medium-12 small-12 columns">
-                    <%= select_tag 'eventtype', options_for_select(EventType.all.collect{ |d| [d.name, d.id] }), {prompt: "Event Type"}  %>
+                    <%= select_tag "query[event_type]", options_for_select(EventType.all.collect{ |d| [d.name, d.id] }), {prompt: "Event Type"}  %>
                   </div>
                 </div>
                 <h5>Attendance</h5>
                 <div>
-                  <%= hidden_field_tag :filter_2500, "0", id: "2500" %>
+                  <%= hidden_field_tag "query[attendance][2500]", "0", id: "2500" %>
                   <label>
-                    <%= check_box_tag :filter_2500 %>
+                    <%= check_box_tag "query[attendance][2500]" %>
                     <span class="overdue">< 2,500</span>
                   </label>
                 </div>
                 <div>
-                  <%= hidden_field_tag :filter_2500_15500, "0", id: "2500_15500" %>
+                  <%= hidden_field_tag "query[attendance][2500_15500]", "0", id: "2500_15500" %>
                   <label>
-                    <%= check_box_tag :filter_2500_15500 %>
+                    <%= check_box_tag "query[attendance][2500_15500]" %>
                     <span class="overdue">2,500 - 15,500</span>
                   </label>
                 </div>
                 <div>
-                  <%= hidden_field_tag :filter_15500_50000, "0", id: "15500_50000" %>
+                  <%= hidden_field_tag "query[attendance][15500_50000]", "0", id: "15500_50000" %>
                   <label>
-                    <%= check_box_tag :filter_15500_50000 %>
+                    <%= check_box_tag "query[attendance][15500_50000]" %>
                     <span class="overdue">15,500 - 50,000</span>
                   </label>
                 </div>
                 <div>
-                  <%= hidden_field_tag :filter_500000, "0", id: "500000" %>
+                  <%= hidden_field_tag "query[attendance][500000]", "0", id: "500000" %>
                   <label>
-                    <%= check_box_tag :filter_500000 %>
+                    <%= check_box_tag "query[attendance][500000]" %>
                     <span class="overdue">> 50,000</span>
                   </label>
                 </div>
@@ -133,7 +133,7 @@
                 <h4>CREATOR:</h4>
                 <div class="row collapse">
                   <div class="small-10 columns">
-                    <%= text_field_tag :creator, '', placeholder: "I'd like to find...", autocomplete: :on %>
+                    <%= text_field_tag "query[creator]", '', placeholder: "I'd like to find...", autocomplete: :on %>
                   </div>
                   <div class="small-2 columns">
                     <button class="button postfix primary"><i class="fi-magnifying-glass"></i></button>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -50,11 +50,11 @@
             </div>
           </div>
         </li>
-        <li class="large-12 columns status_filter">
-          <h5>Status</h5>
-          <div class="checkbox row collapse">
-            <div class="checkbox inline">
-              <% if can? :manage, Plan %>
+        <% if current_user.try(:is_admin?) %>
+          <li class="large-12 columns status_filter">
+            <h5>Status</h5>
+            <div class="checkbox row collapse">
+              <div class="checkbox inline">
                 <div>
                   <%= hidden_field_tag "query[state][draft]", "0", id: "draft" %>
                   <label>
@@ -83,9 +83,9 @@
                     <span class="overdue">Approved</span>
                   </label>
                 </div>
-              <% end %>
+              </div>
             </div>
-          </div>
+        <% end %>
           <div class="checkbox row collapse">
             <div class="checkbox inline">
               <% if can? :manage, Plan %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -11,7 +11,7 @@
 <div class="row ">
   <div class="large-3 medium-3 small-12 columns">
     <%= smart_listing_controls_for(:plans) do %>
-        <!-- # Add search box to form - it submits the form automatically on text change -->
+      <!-- # Add search box to form - it submits the form automatically on text change -->
       <ul class="side-nav large-12 columns">
         <li class="large-12 columns request_search">
           <h4>SEARCH:</h4>
@@ -40,9 +40,11 @@
           <div class="checkbox row collapse">
             <div class="checkbox inline">
               <div>
-              <%= hidden_field_tag :my_plans_check, "0", id: "mr" %>
-              <%= check_box_tag :my_plans_check %>
-              <span class=""><i class="fi-torso"></i><%= "My Plans" %></span>
+                <%= hidden_field_tag :my_plans_check, "0", id: "mr" %>
+                <label>
+                  <%= check_box_tag :my_plans_check %>
+                  <span><i class="fi-torso"></i>My Plans</span>
+                </label>
               </div>
             </div>
           </div>
@@ -52,23 +54,31 @@
               <% if can? :manage, Plan %>
                 <div>
                   <%= hidden_field_tag :submitted_check, "0", id: "draft" %>
-                  <%= check_box_tag :submitted_check %>
-                  <span class="submitted"><%= "Draft" %></span>
+                  <label>
+                    <%= check_box_tag :submitted_check %>
+                    <span class="submitted">Draft</span>
+                  </label>
                 </div>
                 <div>
                   <%= hidden_field_tag :awaiting_review_check, "0", id: "awaiting" %>
-                  <%= check_box_tag :awaiting_review_check %>
-                  <span><%= "Under Review" %></span>
+                  <label>
+                    <%= check_box_tag :awaiting_review_check %>
+                    <span>Under Review</span>
+                  </label>
                 </div>
                 <div>
                   <%= hidden_field_tag :reviewing_check, "0", id: "reviewing" %>
-                  <%= check_box_tag :reviewing_check %>
-                  <span class="overdue"><%= "Revision Requested" %></span>
+                  <label>
+                    <%= check_box_tag :reviewing_check %>
+                    <span class="overdue">Revision Requested</span>
+                  </label>
                 </div>
                 <div>
                   <%= hidden_field_tag :accepted_check, "0", id: "accepted" %>
-                  <%= check_box_tag :accepted_check %>
-                  <span class="overdue"><%= "Approved" %></span>
+                  <label>
+                    <%= check_box_tag :accepted_check %>
+                    <span class="overdue">Approved</span>
+                  </label>
                 </div>
               <% end %>
             </div>
@@ -79,8 +89,10 @@
                 <h5>Alcohol</h5>
                 <div>
                   <%= hidden_field_tag :alcohol_check, "0", id: "alcohol" %>
-                  <%= check_box_tag :alcohol_check %>
-                  <span class="alcohol"><%= "Yes" %></span>
+                  <label>
+                    <%= check_box_tag :alcohol_check %>
+                    <span class="alcohol">Yes</span>
+                  </label>
                 </div>
                 <h5>Event Type</h5>
                 <div class="row collapse">
@@ -91,23 +103,31 @@
                 <h5>Attendance</h5>
                 <div>
                   <%= hidden_field_tag :filter_2500, "0", id: "2500" %>
-                  <%= check_box_tag :filter_2500 %>
-                  <span class="overdue"><%= "< 2,500" %></span>
+                  <label>
+                    <%= check_box_tag :filter_2500 %>
+                    <span class="overdue">< 2,500</span>
+                  </label>
                 </div>
                 <div>
                   <%= hidden_field_tag :filter_2500_15500, "0", id: "2500_15500" %>
-                  <%= check_box_tag :filter_2500_15500 %>
-                  <span class="overdue"><%= "2,500 - 15,500" %></span>
+                  <label>
+                    <%= check_box_tag :filter_2500_15500 %>
+                    <span class="overdue">2,500 - 15,500</span>
+                  </label>
                 </div>
                 <div>
                   <%= hidden_field_tag :filter_15500_50000, "0", id: "15500_50000" %>
-                  <%= check_box_tag :filter_15500_50000 %>
-                  <span class="overdue"><%= "15,500 - 50,000" %></span>
+                  <label>
+                    <%= check_box_tag :filter_15500_50000 %>
+                    <span class="overdue">15,500 - 50,000</span>
+                  </label>
                 </div>
                 <div>
                   <%= hidden_field_tag :filter_500000, "0", id: "500000" %>
-                  <%= check_box_tag :filter_500000 %>
-                  <span class="overdue"><%= "> 50,000" %></span>
+                  <label>
+                    <%= check_box_tag :filter_500000 %>
+                    <span class="overdue">> 50,000</span>
+                  </label>
                 </div>
                 
                 <h4>CREATOR:</h4>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,14 @@ en:
     formats:
       default: "%m/%d/%Y %l:%M %P"
 
+  plans:
+    state:
+      draft: Draft
+      awaiting_review: Under Review
+      being_reviewed: Revision Requested
+      accepted: Approved
+  
+
   notification_mailer:
     subject:
       comment:

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -1,0 +1,45 @@
+require_relative "acceptance_helper"
+
+feature "Plan Index" do
+
+  let(:plan) { create(:plan_awaiting_review) }
+  let(:accepted_plan) { create(:accepted_plan) }
+  let(:admin) { create(:admin) }
+
+  before do
+    plan
+    accepted_plan
+  end
+
+  context "not logged in" do
+
+    before do
+      visit "/plans"
+    end
+    
+    scenario "show all of the accepted plans" do
+      expect(page).to have_content accepted_plan.name
+    end
+    
+    scenario "don't show unaccepted plans" do
+      expect(page).to have_no_content plan.name
+    end
+  end
+
+  context "logged in as an admin" do
+
+    before do
+      sign_in(admin)
+      visit "/plans"
+    end
+    
+    scenario "show all of the accepted plans" do
+      expect(page).to have_content accepted_plan.name
+    end
+    
+    scenario "show unaccepted plans" do
+      expect(page).to have_content plan.name
+    end
+  end
+
+end

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -59,7 +59,7 @@ feature "Plan Index" do
     end
 
     scenario "filters by event type", js: true do
-      select plan.event_type, from: "query_event_type"
+      check plan.event_type.name
       expect(page).to have_content plan.name
       expect(page).to_not have_content accepted_plan.name
     end

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -11,35 +11,88 @@ feature "Plan Index" do
     accepted_plan
   end
 
-  context "not logged in" do
+  context "Guest" do
 
     before do
       visit "/plans"
     end
     
-    scenario "show all of the accepted plans" do
+    scenario "views accepted plans" do
       expect(page).to have_content accepted_plan.name
     end
     
-    scenario "don't show unaccepted plans" do
+    scenario "can't see unaccepted plans" do
       expect(page).to have_no_content plan.name
     end
   end
 
-  context "logged in as an admin" do
+  context "Admin" do
 
     before do
       sign_in(admin)
       visit "/plans"
     end
     
-    scenario "show all of the accepted plans" do
+    scenario "views accepted plans" do
       expect(page).to have_content accepted_plan.name
     end
     
-    scenario "show unaccepted plans" do
+    scenario "views unaccepted plans" do
       expect(page).to have_content plan.name
     end
   end
 
+  context "User" do
+
+    let(:user) { create(:user) }
+    let(:created_plan) { create(:plan) }
+    let(:viewable_plan) { create(:plan) }
+
+    context "with affiliated plans" do
+      before do
+        created_plan.update(creator: user)
+        viewable_plan.users_who_can_view << user
+        
+        sign_in(user)
+        visit "/plans"
+      end
+
+      scenario "views plans they created" do
+        expect(page).to have_content created_plan.name
+      end
+
+      scenario "views plans they can see" do
+        expect(page).to have_content viewable_plan.name
+      end
+
+      scenario "has 'My Plans' checked by default" do
+        expect(page).to have_checked_field("My Plans")
+      end
+
+      scenario "sees only their plans by default" do
+        expect(page).to_not have_content accepted_plan.name
+      end
+
+      scenario "views accepted plans", js: true do
+        uncheck "My Plans"
+        expect(page).to have_content accepted_plan.name
+      end
+    end
+
+    context "without affiliated plans" do
+      before do
+        sign_in(user)
+        visit "/plans"
+      end
+      scenario "views accepted plans" do
+        expect(page).to have_content accepted_plan.name
+      end
+      
+      scenario "can't see unaccepted plans" do
+        expect(page).to have_no_content plan.name
+      end
+
+    end
+  end
+  
 end

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -71,6 +71,11 @@ feature "Plan Index" do
       expect(page).to_not have_selector(".loading")
       expect(all("#plans tr td.attendance").last).to have_content ""
     end
+
+    scenario "filters by start date", js: true do
+      find("#query_start_date").set(high_attendance_plan.end_date + 1.day)
+      expect(page).to_not have_content high_attendance_plan.name
+    end
   end
 
   context "User" do

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -76,6 +76,11 @@ feature "Plan Index" do
       find("#query_start_date").set(high_attendance_plan.end_date + 1.day)
       expect(page).to_not have_content high_attendance_plan.name
     end
+
+    scenario "filters by end date", js: true do
+      find("#query_end_date").set(high_attendance_plan.start_date - 1.day)
+      expect(page).to_not have_content high_attendance_plan.name
+    end
   end
 
   context "User" do

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -66,9 +66,10 @@ feature "Plan Index" do
 
     scenario "sorts by attendance", js: true do
       click_on "Attendance"
-      expect(first("#plans tr td", visible: true)).to have_content high_attendance_plan.name
-      click_on "Attendance"
-      expect(all("#plans tr td", visible: true).last).to have_content high_attendance_plan.end_date.strftime("%D %l:%M %P")
+      expect(page).to_not have_selector(".loading")
+      expect(first("#plans tr td.name", visible: true)).to have_content high_attendance_plan.name
+      expect(page).to_not have_selector(".loading")
+      expect(all("#plans tr td.attendance").last).to have_content ""
     end
   end
 
@@ -120,6 +121,10 @@ feature "Plan Index" do
       
       scenario "can't see unaccepted plans" do
         expect(page).to have_no_content plan.name
+      end
+
+      scenario "can't see plan status" do
+        expect(page).to_not have_content "Status"
       end
 
     end

--- a/spec/acceptance/plan_index_spec.rb
+++ b/spec/acceptance/plan_index_spec.rb
@@ -28,7 +28,10 @@ feature "Plan Index" do
 
   context "Admin" do
 
+    let(:high_attendance_plan) { create(:plan, operation_periods: [ create(:operation_period, attendance: 45000) ]) }
+
     before do
+      high_attendance_plan
       sign_in(admin)
       visit "/plans"
     end
@@ -39,6 +42,33 @@ feature "Plan Index" do
     
     scenario "views unaccepted plans" do
       expect(page).to have_content plan.name
+    end
+
+    scenario "filters by state", js: true do
+      check "Approved"
+      expect(page).to have_content accepted_plan.name
+      expect(page).to_not have_content plan.name
+      check "Under Review"
+      expect(page).to have_content plan.name
+    end
+
+    scenario "filters by attendance", js: true do
+      check "15,500 - 50,000"
+      expect(page).to have_content high_attendance_plan.name
+      expect(page).to_not have_content plan.name
+    end
+
+    scenario "filters by event type", js: true do
+      select plan.event_type, from: "query_event_type"
+      expect(page).to have_content plan.name
+      expect(page).to_not have_content accepted_plan.name
+    end
+
+    scenario "sorts by attendance", js: true do
+      click_on "Attendance"
+      expect(first("#plans tr td", visible: true)).to have_content high_attendance_plan.name
+      click_on "Attendance"
+      expect(all("#plans tr td", visible: true).last).to have_content high_attendance_plan.end_date.strftime("%D %l:%M %P")
     end
   end
 

--- a/spec/acceptance/plans_spec.rb
+++ b/spec/acceptance/plans_spec.rb
@@ -3,40 +3,8 @@ require_relative "./acceptance_helper"
 feature "Plan" do
   
   let(:plan) { FactoryGirl.create(:plan) }
-  let(:accepted) { FactoryGirl.create(:plan) }
   let(:admin) { FactoryGirl.create(:admin) }
   let(:permitters) { 1.upto(3).map{ |i| FactoryGirl.create(:permitter) }.sort_by(&:name) }
-
-  context "not logged in" do
-    scenario "show all of the accepted plans" do
-      accepted.submit!
-      accepted.review!
-      accepted.accept!
-      visit "/plans"
-      expect(page).to have_content "#{accepted.name}"
-    end
-    scenario "don't show unaccepted plans" do
-      visit "/plans"
-      expect(page).to have_no_content "#{plan.name}"
-    end
-  end
-
-  context "logged in as an admin" do
-    scenario "show all of the accepted plans" do
-      sign_in(admin)
-      accepted.submit!
-      accepted.review!
-      accepted.accept!
-      visit "/plans"
-      expect(page).to have_content "#{accepted.name}"
-    end
-    scenario "show unaccepted plans" do
-      sign_in(admin)
-      plan.submit!
-      visit "/plans"
-      expect(page).to have_content "#{plan.name}"
-    end
-  end
 
   context "create a new plan" do
     

--- a/spec/acceptance/support/helpers.rb
+++ b/spec/acceptance/support/helpers.rb
@@ -14,7 +14,9 @@ module HelperMethods
   def save_screenshot
     @index ||= 0
     @index = @index + 1
-    super("#{Rails.root}/tmp/phantomjs/#{@index}.jpg", full: true)
+    filename = "#{Rails.root}/tmp/phantomjs/#{@index}.jpg"
+    super(filename, full: true)
+    system("open -a Preview #{filename} &")
   end
 
   def post_comment(body)

--- a/spec/acceptance/support/helpers.rb
+++ b/spec/acceptance/support/helpers.rb
@@ -16,7 +16,6 @@ module HelperMethods
     @index = @index + 1
     filename = "#{Rails.root}/tmp/phantomjs/#{@index}.jpg"
     super(filename, full: true)
-    system("open -a Preview #{filename} &")
   end
 
   def post_comment(body)

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -21,6 +21,10 @@ FactoryGirl.define do
     factory :plan_awaiting_review do
       workflow_state :awaiting_review
     end
+
+    factory :accepted_plan do
+      workflow_state :accepted
+    end
   end
 
   factory :comment do


### PR DESCRIPTION
When a user has plans that they own, created, or are collaborating on, the plan index will by default check the "My Plans" box and show only those plans.

Changes attendance and state filters to work on OR logic and fixes the attendance query to agree with what is being displayed.

Converts event types filters to checkboxes, enables date filtering, and adds a status column for admins.

Fixes #46.
Fixes #53.
Fixes #51.
Fixes #52.
Fixes #54.
