### PR TITLE
Add asset map feature

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -19,7 +19,7 @@ $yellow: #EDD364;
 
 /* Element Colors */
 $typography: #58585B;
-$btntext: #FFF; 
+$btntext: #FFF;
 
 /* TYPOGRAPHY */
 
@@ -91,7 +91,7 @@ ol{
   background: #fff;
   border-bottom: 1px solid #f5f5f5;
   .name {
-      margin: .25em 0em 0em .75em;    
+      margin: .25em 0em 0em .75em;
     a{
       font-family: $primary-font;
       font-size: 1.5em;
@@ -175,16 +175,16 @@ legend{
   -webkit-border-radius: 4px;
   border-radius: 4px; /* future proofing */
   h2{
-    color: $promptlyblue;    
+    color: $promptlyblue;
   }
-  i{ 
+  i{
     font-size: 10em;
-  }  
+  }
   &:hover{
     background: $promptlyblue;
     color: #fff;
     h2{
-      color: #fff;    
+      color: #fff;
     }
   }
 
@@ -196,11 +196,11 @@ legend{
 /* https://www.flickr.com/photos/audiolucistore/14163042905/in/photolist-nzxidV-LaARx-cxUcBu-9uZpk3-5erWNG-6Jpuud-xsZh8-ovRNyN-ovMGNz-cu64t-bncE6P-hnZzLf-kXy2-bPMHr6-ao63dG-5AmR7f-5nRsb3-dQjSHb-6W49Xi-4YPqqU-72j5yj-7m7B7h-a42jmC-qCzR6b-sSF1Mq-7QpV8y-rrtnoF-4Mt8dp-isjzoi-fGXeu1-58jBvL-7vEVHQ-qcQE2T-e1wDLh-8RViG5-55yjt2-55R1Tu-ihgH2m-4wttVC-6225bv-q62zMt-68jpVn-qMU7aT-oHcbMi-2RF5eT-do8JT3-56eXRT-dV8sXM-6UT19W-7UNsX4*/
 .browse-landing{
   height: 300px;
-  background: #fff;  
+  background: #fff;
 }
 /*https://www.flickr.com/search/?license=4%2C5%2C6%2C9%2C10&advanced=1&text=book%20shelf*/
 .new-plan-landing{
-  height: 300px;  
+  height: 300px;
   background-image: asset-url('event_image.png');
 }
 /*https://www.flickr.com/photos/goincase/5227334827/in/photolist-8XVswx-e1H2wz-e1H3Kg-ekwWmw-e5EhXp-3JGb4Y-e5EgaK-8jQw3k-9WJkPJ-6CuXU3-8p1kRq-88McgK-gcNj9F-8ZYJNJ-gcGgk8-9pW7GC-mrmShP-aDNQjH-gcP8ca-dKuzK9-6Dzu4H-2WJec-e1H1D6-e1NDSL-fHj6iU-jxYo2D-iWV5n6-ooSDcT-ia8dgf-p6TSpU-e1H2je-78vw29-ohYFB2-dPVD1P-gcQMW3-88QqRf-88QqAh-6CrgKt-aDSDr5-9pQmVW-mrm52b-8ZYJgW-88McoD-gcP6qe-9pWMWy-9pTGHr-gcFJVb-8ZVCMi-9pPUQh-aokzW3*/
@@ -213,7 +213,7 @@ legend{
     font-size: .75rem;
     color: $darkgray;
     text-align: left;
-  }  
+  }
   .asset_table {
     display: none;
   }
@@ -239,10 +239,10 @@ legend{
   }
   table tr.even, table tr.alt, table tr:nth-of-type(even) {
     background: #fff;
-  } 
+  }
   table thead{
     background: #fff;
-  }  
+  }
   .has-tip{
     font-size: 1.75em;
     border: none;
@@ -274,7 +274,7 @@ legend{
 .new-event-info{
   margin-top: 2em;
   border: 1px solid #E6E7E8;
-  padding: 1em; 
+  padding: 1em;
 }
 .new-event-info h6{
   background: #fff;
@@ -308,59 +308,59 @@ fieldset{
   margin-bottom: 4em;
 }
 
-.breadcrumb { 
-  list-style: none; 
-  overflow: hidden; 
+.breadcrumb {
+  list-style: none;
+  overflow: hidden;
   font: 18px Helvetica, Arial, Sans-Serif;
 }
-.breadcrumb li { 
-  float: left; 
+.breadcrumb li {
+  float: left;
 }
 .breadcrumb li a {
   color: white;
   height: 50px;
-  text-decoration: none; 
+  text-decoration: none;
   padding: 14px 0 10px 50px;
-  background: $mediumgray;                  
-  position: relative; 
+  background: $mediumgray;
+  position: relative;
   display: block;
   float: left;
 }
-.breadcrumb li a:after { 
-  content: " "; 
-  display: block; 
-  width: 0; 
+.breadcrumb li a:after {
+  content: " ";
+  display: block;
+  width: 0;
   height: 0;
   border-top: 50px solid transparent;           /* Go big on the size, and let overflow hide */
   border-bottom: 50px solid transparent;
   border-left: 30px solid $mediumgray;
   position: absolute;
   top: 50%;
-  margin-top: -50px; 
+  margin-top: -50px;
   left: 100%;
   z-index: 2;
   &.active {
     border-left: 30px solid #f19b3b;
-  } 
+  }
   &.approved {
     content: none;
     color: pink;
   }
 }
-.breadcrumb li a:before { 
-  content: " "; 
-  display: block; 
-  width: 0; 
+.breadcrumb li a:before {
+  content: " ";
+  display: block;
+  width: 0;
   height: 0;
-  border-top: 50px solid transparent;       
+  border-top: 50px solid transparent;
   border-bottom: 50px solid transparent;
   border-left: 30px solid white;
   position: absolute;
   top: 50%;
-  margin-top: -50px; 
+  margin-top: -50px;
   margin-left: 1px;
   left: 100%;
-  z-index: 1; 
+  z-index: 1;
 }
 #users_table, .first_aid_table, #mobile_team_table, #transport_table, #dispatch_table{
   border: none;
@@ -373,7 +373,7 @@ fieldset{
     background: none;
     color: $mediumgray;
     font-weight: normal;
-  }  
+  }
 }
 
 .tabs dd.active a, .tabs .tab-title.active a {
@@ -388,7 +388,7 @@ fieldset{
   background-color: #fafafa;
 }
 .tabs dd > a, .tabs .tab-title > a {
-  background-color: #FFF; 
+  background-color: #FFF;
   color: $mediumgray;
   font-family: $primary-font;
   border-bottom: 2px solid $lightgray;
@@ -434,7 +434,7 @@ input[type="checkbox"]{
 
 /* BUTTONS */
 .button{
-  background: #789fd3; 
+  background: #789fd3;
   color: #fff;
 }
 
@@ -519,18 +519,49 @@ input[type="checkbox"]{
   border-color: #ccc #ccc #999 #ccc;
   -webkit-box-shadow: rgba(64, 64, 64, 0.5) 0 2px 5px;
   -moz-box-shadow: rgba(64, 64, 64, 0.5) 0 2px 5px;
-  box-shadow: rgba(64, 64, 64, 0.1) 0 2px 5px;  
+  box-shadow: rgba(64, 64, 64, 0.1) 0 2px 5px;
 }
+
 /* For google maps and twitter bootstrap*/
 .asset_map {
   width: 100%;
   height: 350px;
+  margin-bottom: 20px;
+
   img {
     max-width: none;
   }
   label {
-    width: auto; 
+    width: auto;
     display:inline;
+  }
+}
+
+.asset_map_legend {
+  margin: 0px 0 10px;
+  font-family: $secondary-font;
+  text-transform: uppercase;
+  font-weight: bold;
+  color: #4d4d4d; // Matches label color
+
+  span {
+    display: inline-block;
+    margin-left: 2em;
+    padding-left: 4px;
+    border-left: 1.5em solid #fff;
+  }
+
+  .marker_legend_firstaid {
+    border-left-color: #ca0020;
+  }
+  .marker_legend_mobileteam {
+    border-left-color: #0571b0;
+  }
+  .marker_legend_transport {
+    border-left-color: #85048a;
+  }
+  .marker_legend_dispatch {
+    border-left-color: #45403e;
   }
 }
 
@@ -547,8 +578,8 @@ input[type="checkbox"]{
   .tabs .tab-title > a {
     margin-bottom: 0
   }
-  
-  .content {                            
+
+  .content {
     padding: 2em;
     border: 2px solid #E6E7E8;
     border-top: none;
@@ -560,6 +591,6 @@ div.input.radio_buttons {
   margin-top: 0.5rem;
 }
 .supplementary-document {
-  margin-bottom: 1.5em;                            
+  margin-bottom: 1.5em;
 }
 

--- a/app/views/operation_periods/_asset_map.erb
+++ b/app/views/operation_periods/_asset_map.erb
@@ -1,0 +1,171 @@
+<div class="row">
+  <div class="large-12 columns">
+    <div class="asset_map_legend">
+      <strong>ASSETS:</strong>
+      <span class="marker_legend_firstaid">First Aid</span>
+      <span class="marker_legend_mobileteam">Mobile Team</span>
+      <span class="marker_legend_transport">Transport</span>
+      <span class="marker_legend_dispatch">Dispatch</span>
+    </div>
+    <div class="asset_map" id="<%= operation_period.id %>_asset_map"></div>
+    <script type="text/javascript">
+    $(function() {
+      var firstAidStations = <%== json_escape(operation_period.first_aid_stations.to_json) %>;
+      var mobileTeams = <%== json_escape(operation_period.mobile_teams.to_json) %>;
+      var transports = <%== json_escape(operation_period.transports.to_json) %>;
+      var dispatches = <%== json_escape(operation_period.dispatchs.to_json) %>;
+
+      // to_json produces null values, which are displayed as "null", which is
+      // not ideal. This sets a sensible alternative.
+      var i, j, property;
+      var datasets = [firstAidStations, mobileTeams, transports, dispatches];
+
+      for (i = 0; i < datasets.length; i++) {
+        for (j = 0; j < datasets[i].length; j++) {
+          for (property in datasets[i][j]) {
+              if (datasets[i][j].hasOwnProperty(property)) {
+                if (datasets[i][j][property] === null) {
+                  datasets[i][j][property] = 'Not entered';
+                }
+              }
+          }
+        }
+      }
+
+      var mapOptions = {
+        center: new google.maps.LatLng(37.773972, -122.431297),
+        zoom: 12,
+        mapTypeId: google.maps.MapTypeId.NORMAL,
+        panControl: true,
+        scaleControl: false,
+        streetViewControl: true,
+        overviewMapControl: true
+      };
+
+      map = new google.maps.Map(document.getElementById('<%= operation_period.id %>_asset_map'), mapOptions);
+      var markers = [];
+
+      function fitBoundsToVisibleMarkers() {
+        var bounds = new google.maps.LatLngBounds();
+        for (var i=0; i<markers.length; i++) {
+          if(markers[i].getVisible()) {
+            bounds.extend( markers[i].getPosition() );
+          }
+        }
+        map.fitBounds(bounds);
+      }
+
+      function makeInfoWindowListener(infowindow, map, marker) {
+        return function() {
+          infowindow.open(map, marker);
+        }
+      }
+
+      function addMarkers(collection, options) {
+        for (var i = 0; i < collection.length; i++) {
+          var obj = collection[i];
+          console.log("Adding", collection[i]);
+          var latlng = {lat: Number(obj.lat), lng: Number(obj.lng)};
+
+          var infowindow = new google.maps.InfoWindow({
+            content: options.content(obj)
+          });
+
+          var marker = new google.maps.Marker({
+            position: latlng,
+            map: map,
+            icon: options.icon
+          });
+
+          marker.addListener('click', makeInfoWindowListener(infowindow, map, marker));
+
+          markers.push(marker);
+        }
+      }
+
+      addMarkers(firstAidStations, {
+        icon: {
+          path: google.maps.SymbolPath.BACKWARD_CLOSED_ARROW,
+          scale: 5,
+          fillColor: '#ca0020',
+          fillOpacity: 1.0,
+          strokeColor:  '#ca0020',
+          strokeWeight: 2
+        },
+        content: function(obj) {
+          var content = '<div><strong>First Aid Station</strong></div>';
+          content += '<div>' + obj.name + '</div>';
+          content += '<div><strong>Location</strong>: ' + obj.location + '</div>';
+          content += '<div><strong>Contact Name</strong>: ' + obj.contact_name + '</div>';
+          content += '<div><strong>Phone</strong>: ' + obj.contact_phone + '</div>';
+          content += '<div><strong>EMTs</strong>: ' + obj.emt + '</div>';
+          content += '<div><strong>RNs</strong>: ' + obj.rn + '</div>';
+          content += '<div><strong>MDs</strong>: ' + obj.md + '</div>';
+          return content;
+        }
+      });
+      addMarkers(mobileTeams, {
+        icon: {
+          path: google.maps.SymbolPath.BACKWARD_CLOSED_ARROW,
+          scale: 5,
+          fillColor: '#0571b0',
+          fillOpacity: 1.0,
+          strokeColor:  '#0571b0',
+          strokeWeight: 2
+        },
+        content: function(obj) {
+          var content = '<div><strong>Mobile Team</strong></div>';
+          content += '<div>' + obj.name + '</div>';
+          content += '<div><strong>Location</strong>: ' + obj.location + '</div>';
+          content += '<div><strong>Contact Name</strong>: ' + obj.contact_name + '</div>';
+          content += '<div><strong>Phone</strong>: ' + obj.contact_phone + '</div>';
+          content += '<div><strong>Level</strong>: ' + obj.level + '</div>';
+          content += '<div><strong>Type</strong>: ' + obj.mobile_team_type + '</div>';
+          content += '<div><strong>AEDs</strong>: ' + obj.aed + '</div>';
+          return content;
+        }
+      });
+      addMarkers(transports, {
+        icon: {
+          path: google.maps.SymbolPath.BACKWARD_CLOSED_ARROW,
+          scale: 5,
+          fillColor: '#85048a',
+          fillOpacity: 1.0,
+          strokeColor:  '#85048a',
+          strokeWeight: 2
+        },
+        content: function(obj) {
+          var content = '<div><strong>Transport</strong></div>';
+          content += '<div>' + obj.name + '</div>';
+          content += '<div><strong>Location</strong>: ' + obj.location + '</div>';
+          content += '<div><strong>Contact Name</strong>: ' + obj.contact_name + '</div>';
+          content += '<div><strong>Phone</strong>: ' + obj.contact_phone + '</div>';
+          content += '<div><strong>Level</strong>: ' + obj.level + '</div>';
+          return content;
+        }
+      });
+      addMarkers(dispatches, {
+        icon: {
+          path: google.maps.SymbolPath.BACKWARD_CLOSED_ARROW,
+          scale: 5,
+          fillColor: '#45403e',
+          fillOpacity: 1.0,
+          strokeColor:  '#45403e',
+          strokeWeight: 2
+        },
+        content: function(obj) {
+          var content = '<div><strong>Dispatcher</strong></div>';
+          content += '<div>' + obj.name + '</div>';
+          content += '<div><strong>Contact Name</strong>: ' + obj.contact_name + '</div>';
+          content += '<div><strong>Phone</strong>: ' + obj.contact_phone + '</div>';
+          return content;
+        }
+      });
+
+      fitBoundsToVisibleMarkers();
+
+    });
+    </script>
+  </div>
+</div>
+

--- a/app/views/operation_periods/_form.html.erb
+++ b/app/views/operation_periods/_form.html.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <%= op.input_field :id, as: :hidden %>
-    
+
     <div class="row">
       <div class="small-2 columns input_label">
         <%= op.label :start_date, class: "inline", label: "START" %>
@@ -42,7 +42,7 @@
       <div class="large-4 columns">
         <%= render 'plans/comment_form', plan: @plan, title: "#{op.object.id}_end_date" %>
       </div>
-    </div>        
+    </div>
     <div class="row">
       <div class="small-2 columns input_label">
         <%= op.label :attendance, class: "inline" do %>
@@ -56,6 +56,9 @@
         <%= render 'plans/comment_form', plan: @plan, title: "#{op.object.id}_attendance" %>
       </div>
     </div>
+
+    <%= render 'operation_periods/asset_map', operation_period: op.object %>
+
     <div class="row">
       <div class="large-9 columns">
         <fieldset>
@@ -82,19 +85,19 @@
             <div class="large-12 columns">
               <a id="new_first_aid_station" class="button primary tiny radius" href="#" data-reveal-id="new-first-aid-station-<%= count - 1 %>"><i class="fi-plus"></i>&nbsp;ADD FIRST AID STATION</a>
               <%= render partial: 'plans/new_first_aid_station', :locals => { :operation_period => op.object, :operation => "operation_periods[id][#{count}]", :operation_period_index => count - 1 } %>
-            </div>  
+            </div>
           </div>
         </fieldset>
       </div>
       <div class="large-3 columns right end">
         <%= render 'plans/comment_form', plan: @plan, title: "#{op.object.id}_first_aid_stations" %>
-      </div>          
+      </div>
     </div>
     <div class="row">
       <div class="large-9 columns">
         <fieldset>
           <legend>MOBILE TEAMS</legend>
-          <div class="row">          
+          <div class="row">
             <table id="mobile_team_table">
               <thead>
                 <th>Name</th>
@@ -109,14 +112,14 @@
               <tbody>
                 <%= render 'plans/mobile_team_show', op: op %>
               </tbody>
-            </table> 
+            </table>
             <div class="large-12 columns">
               <a id="new_mobile_team" class="button primary tiny radius" href="#" data-reveal-id="new-mobile-team-<%= count - 1 %>"><i class="fi-plus"></i>&nbsp;ADD MOBILE TEAM</a>
               <%= render partial: 'plans/new_mobile_team', :locals => { :operation_period => op.object, :operation_period_index => count - 1 } %>
             </div>
-          </div> 
+          </div>
         </fieldset>
-      </div>  
+      </div>
       <div class="large-3 columns right end">
         <%= render 'plans/comment_form', plan: @plan, title: "#{op.object.id}_mobile_teams" %>
       </div>
@@ -126,7 +129,7 @@
       <div class="large-9 columns">
         <fieldset>
           <legend>TRANSPORTS</legend>
-          <div class="row">              
+          <div class="row">
             <%= simple_fields_for :transports do |t| %>
               <table id="transport_table">
                 <thead>
@@ -151,11 +154,11 @@
       <div class="large-3 columns right end">
         <%= render 'plans/comment_form', plan: @plan, title: "#{op.object.id}_transport" %>
       </div>
-    </div>   
+    </div>
     <div class="row">
-      <div class="large-9 columns">            
+      <div class="large-9 columns">
         <fieldset>
-          <div class="row">              
+          <div class="row">
             <legend>DISPATCH</legend>
             <%= simple_fields_for :dispatchs do |d| %>
               <table id="dispatch_table">
@@ -179,7 +182,7 @@
       </div>
       <div class="large-3 columns right end">
         <%= render 'plans/comment_form', plan: @plan, title: "#{op.object.id}_dispatch" %>
-      </div>          
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/operation_periods/_operation_period.html.erb
+++ b/app/views/operation_periods/_operation_period.html.erb
@@ -1,5 +1,5 @@
 <div class="content <%= "active" if count == 1 %> <%= "operation-period-#{operation_period.id}" %>" id="panel<%= count %>">
-  
+
   <div class="row">
     <div class="small-2 columns input_label">
       <label>Start</label>
@@ -21,7 +21,7 @@
     <div class="large-4 columns">
       <%= render 'plans/comment_form', plan: @plan, title: "#{operation_period.id}_end_date" %>
     </div>
-  </div>        
+  </div>
   <div class="row">
     <div class="small-2 columns input_label">
       <label>Crowd Size</label>
@@ -33,6 +33,9 @@
       <%= render 'plans/comment_form', plan: @plan, title: "#{operation_period.id}_attendance" %>
     </div>
   </div>
+
+  <%= render 'operation_periods/asset_map', operation_period: operation_period %>
+
   <div class="row">
     <div class="large-9 columns">
       <fieldset>
@@ -60,13 +63,13 @@
     </div>
     <div class="large-3 columns right end">
       <%= render 'plans/comment_form', plan: @plan, title: "#{operation_period.id}_first_aid_stations" %>
-    </div>          
+    </div>
   </div>
   <div class="row">
     <div class="large-9 columns">
       <fieldset>
         <legend>MOBILE TEAMS</legend>
-        <div class="row">          
+        <div class="row">
           <table id="mobile_team_table">
             <thead>
               <th>Name</th>
@@ -81,10 +84,10 @@
             <tbody>
               <%= render partial: "mobile_teams/row", collection: operation_period.mobile_teams, as: :mobile_team %>
             </tbody>
-          </table> 
-        </div> 
+          </table>
+        </div>
       </fieldset>
-    </div>  
+    </div>
     <div class="large-3 columns right end">
       <%= render 'plans/comment_form', plan: @plan, title: "#{operation_period.id}_mobile_teams" %>
     </div>
@@ -94,7 +97,7 @@
     <div class="large-9 columns">
       <fieldset>
         <legend>TRANSPORTs</legend>
-        <div class="row">              
+        <div class="row">
           <%= simple_fields_for :transports do |t| %>
             <table id="transport_table">
               <thead>
@@ -115,12 +118,12 @@
     <div class="large-3 columns right end">
       <%= render 'plans/comment_form', plan: @plan, title: "#{operation_period.id}_transport" %>
     </div>
-  </div>   
+  </div>
   <div class="row">
-    <div class="large-9 columns">            
+    <div class="large-9 columns">
       <fieldset>
         <legend>DISPATCHES</legend>
-        <div class="row">              
+        <div class="row">
           <table id="dispatch_table">
             <thead>
               <th>Name</th>
@@ -137,6 +140,6 @@
     </div>
     <div class="large-3 columns right end">
       <%= render 'plans/comment_form', plan: @plan, title: "#{operation_period.id}_dispatch" %>
-    </div>          
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Addresses #8 with a map that shows asset locations and details. The map displays on the view and edit pages

<img width="1024" alt="screen shot 2016-01-26 at 7 15 33 pm" src="https://cloud.githubusercontent.com/assets/86435/12599838/1b45589c-c463-11e5-95ba-d33bfade7511.png">

Two notes: 
- I dropped the JS inline on the map partial because it's fairly simple and self-contained. Let me know if you'd prefer me to pull it out into a js file.  
- My text editor is configured to strip whitespace from the end of lines, which has added noise to the PR. Happy to make a cleaner PR. 
