### PR TITLE
Fix test setup conflict - fixes #134

### DIFF
--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -13,22 +13,22 @@ FactoryGirl.define do
       end
     end
   end
-  
+
   factory :operation_period do
     start_date DateTime.now
     end_date   DateTime.now + 1.day
-    attendance Faker::Number.number(5)     
+    attendance Faker::Number.number(5)
   end
 
   factory :plan do
     name { Faker::Lorem.words(3).join }
     event_type
-    operation_periods = FactoryGirl.create(:operation_period)
+    operation_periods { [FactoryGirl.create(:operation_period)] }
 
     factory :plan_under_review do
       workflow_state :under_review
     end
-    
+
     factory :draft do
       workflow_state :draft
     end


### PR DESCRIPTION
FactoryGirl was attempting to create operation periods before the relations where set up in the database. This broke the first-run test setup (commands like `RAILS_ENV=test rake db:create`)
