### PR TITLE
Approval Notification List

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,7 +2,8 @@ class AdminController < ApplicationController
   before_filter :verify_is_admin
 
   def index
-
+    @notification_groups = NotificationGroup.order("id ASC")
+    
     respond_to do |format|
       format.html # index.html.erb
     end

--- a/app/controllers/notification_groups_controller.rb
+++ b/app/controllers/notification_groups_controller.rb
@@ -1,0 +1,20 @@
+class NotificationGroupsController < ApplicationController
+
+  load_and_authorize_resource
+  
+  def show
+  end
+
+  def update
+    @notification_group.update(notification_group_params)
+    flash[:success] = "Notification group updated."
+    redirect_to @notification_group
+  end
+
+  private
+
+  def notification_group_params
+    params.require(:notification_group).permit(notification_group_memberships_attributes: [ :id, :user_id, :_destroy ])
+  end
+  
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -35,6 +35,7 @@ class Ability
       cannot [:create, :edit, :destroy, :show], Plan
       cannot :read, Provider
       cannot :read, Permitter
+      cannot :read, NotificationGroup
     end
     cannot :edit, PostEventTreatmentReport, submitted: true
     cannot [ :edit, :destroy ], TreatmentRecord, post_event_treatment_report: { submitted: true }

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -1,0 +1,4 @@
+class NotificationGroup < ActiveRecord::Base
+  has_many :notification_group_memberships, inverse_of: :notification_group, dependent: :destroy
+  has_many :members, through: :notification_group_memberships, source: :user
+end

--- a/app/models/notification_group.rb
+++ b/app/models/notification_group.rb
@@ -1,4 +1,10 @@
 class NotificationGroup < ActiveRecord::Base
   has_many :notification_group_memberships, inverse_of: :notification_group, dependent: :destroy
   has_many :members, through: :notification_group_memberships, source: :user
+
+  accepts_nested_attributes_for :notification_group_memberships, allow_destroy: true
+  
+  def to_s
+    name
+  end
 end

--- a/app/models/notification_group_membership.rb
+++ b/app/models/notification_group_membership.rb
@@ -1,0 +1,7 @@
+class NotificationGroupMembership < ActiveRecord::Base
+  belongs_to :notification_group, inverse_of: :notification_group_memberships
+  belongs_to :user, inverse_of: :notification_group_memberships
+
+  validates :notification_group, presence: true
+  validates :user, presence: true, uniqueness: { scope: :notification_group }
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,25 +33,3 @@ class Organization < ActiveRecord::Base
     end
   end
 end
-
-class NullOrganization
-  def id
-    0
-  end
-  
-  def name
-    'N/A'
-  end
-
-  def email
-    'zombie@fake.com'
-  end
-
-  def phone_number
-    '9999999999'
-  end
-
-  def address
-    '123 fake st'
-  end
-end

--- a/app/models/organization_type.rb
+++ b/app/models/organization_type.rb
@@ -24,4 +24,27 @@ class OrganizationType < ActiveRecord::Base
     type.present? ? organizations = Organization.all.where(organization_type_id: type.id) : organizations =[ NullOrganization.new]
     organizations.empty? ? organizations =[ NullOrganization.new] : organizations
   end
+  
+  class NullOrganization
+    def id
+      0
+    end
+    
+    def name
+      'N/A'
+    end
+
+    def email
+      'zombie@fake.com'
+    end
+
+    def phone_number
+      '9999999999'
+    end
+
+    def address
+      '123 fake st'
+    end
+  end
+
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -236,7 +236,9 @@ class Plan < ActiveRecord::Base
     end
 
     def notify_stakeholders(key)
-      stakeholders.each do |stakeholder|
+      users_to_notify = (stakeholders + User.to_notify_on("plan.#{key}")).uniq
+      
+      users_to_notify.each do |stakeholder|
         stakeholder.notifications.create(subject: self, key: key)
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,13 @@ class User < ActiveRecord::Base
   validates :name, presence: true
   validates :phone_number, presence: true
 
-  scope :to_notify_on, -> notification_type { joins(:notification_groups).where("notification_groups.notification_type" => notification_type) }
+  scope :to_notify_on, -> (notification_type) do
+    if notification_type.present?
+      joins(:notification_groups).where("notification_groups.notification_type" => notification_type)
+    else
+      none
+    end
+  end
 
   after_create do
     Invitation.claim_invitations(self)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,8 @@ class User < ActiveRecord::Base
   has_many :providers_users
   has_many :organization_users
   has_many :organizations, through: :organizations_users
+  has_many :notification_group_memberships, inverse_of: :user, dependent: :destroy
+  has_many :notification_groups, through: :notification_group_memberships, source: :notification_group, inverse_of: :members
 
   roles_attribute :roles_mask
 
@@ -60,6 +62,8 @@ class User < ActiveRecord::Base
 
   validates :name, presence: true
   validates :phone_number, presence: true
+
+  scope :to_notify_on, -> notification_type { joins(:notification_groups).where("notification_groups.notification_type" => notification_type) }
 
   after_create do
     Invitation.claim_invitations(self)

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -19,3 +19,15 @@
     <%= link_to "Manage Venues", venues_path, class: "button primary small" %>
   </div>
 </div>
+
+<div class="row">
+  <div class="small-12 columns">
+    <h2>Notification Groups</h2>
+    <ul>
+      <% @notification_groups.each do |notification_group| %>
+        <li><%= link_to notification_group.name, notification_group %>
+      <% end %>
+    </ul>
+  </div>
+</div>
+

--- a/app/views/notification_groups/show.html.erb
+++ b/app/views/notification_groups/show.html.erb
@@ -1,0 +1,44 @@
+<div class="row">
+  <div class="pageHeader small-12 large-12 columns">
+    <span class="pageTitle large-9 columns">
+      <h2><%= @notification_group.name %></h2>
+      <p><%= @notification_group.description %></p>
+    </span>
+  </div>
+</div>
+<div class="row spacing">
+  <div class="large-7">
+    <%= simple_form_for @notification_group do |f| %>
+      
+      <table class="table table-hover datatable small-12 twelve" id="organization-users">
+        <thead>
+          <tr>
+            <th width="100">Add to Notification Group</th>
+
+            <th width="300">Name</th>
+            <th width="300">Email</th>
+            <th width="100">Role</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% User.all.each do |user| %>
+            <%= f.simple_fields_for :notification_group_memberships, @notification_group.notification_group_memberships.detect{|x| x.user_id == user.id } || @notification_group.notification_group_memberships.build(user: user) do |g| %>
+              <tr>
+                <td>
+                  <%= g.hidden_field :user_id %>
+                  <%= g.check_box :_destroy, { checked: g.object.persisted? }, "0", "1" %>
+                </td>
+                <td><%= user.name %></td>
+                <td><%= user.email %></td>
+                <td><%= user.role %></td>
+              </tr>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+      
+      <%= f.submit class: "button" %>
+    <% end %>
+    <%= link_to '< Back', :admin %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :replies, only: :create
   end
   resources :event_types
+  resources :notification_groups, only: [ :show, :update ]
   resources :notifications, only: :update
   resources :operation_periods, only: [ :update, :destroy ] do
     resources :clones, only: :create

--- a/db/migrate/20160323125033_create_notification_groups.rb
+++ b/db/migrate/20160323125033_create_notification_groups.rb
@@ -1,0 +1,10 @@
+class CreateNotificationGroups < ActiveRecord::Migration
+  def change
+    create_table :notification_groups do |t|
+      t.string :name
+      t.string :notification_type
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160323125033_create_notification_groups.rb
+++ b/db/migrate/20160323125033_create_notification_groups.rb
@@ -2,6 +2,7 @@ class CreateNotificationGroups < ActiveRecord::Migration
   def change
     create_table :notification_groups do |t|
       t.string :name
+      t.text :description
       t.string :notification_type
 
       t.timestamps null: false

--- a/db/migrate/20160323125120_create_notification_group_memberships.rb
+++ b/db/migrate/20160323125120_create_notification_group_memberships.rb
@@ -1,0 +1,11 @@
+class CreateNotificationGroupMemberships < ActiveRecord::Migration
+  def change
+    create_table :notification_group_memberships do |t|
+      t.belongs_to :notification_group, index: true, foreign_key: true
+      t.belongs_to :user, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+    add_index :notification_group_memberships, [ :notification_group_id, :user_id ], unique: true, name: "index_notification_group_memberships_on_ng_id_and_user_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160318135317) do
+ActiveRecord::Schema.define(version: 20160323125120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,6 +126,24 @@ ActiveRecord::Schema.define(version: 20160318135317) do
     t.integer "mobile_team_id"
     t.integer "user_id"
     t.boolean "contact"
+  end
+
+  create_table "notification_group_memberships", force: :cascade do |t|
+    t.integer  "notification_group_id"
+    t.integer  "user_id"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+  end
+
+  add_index "notification_group_memberships", ["notification_group_id", "user_id"], name: "index_notification_group_memberships_on_ng_id_and_user_id", unique: true, using: :btree
+  add_index "notification_group_memberships", ["notification_group_id"], name: "index_notification_group_memberships_on_notification_group_id", using: :btree
+  add_index "notification_group_memberships", ["user_id"], name: "index_notification_group_memberships_on_user_id", using: :btree
+
+  create_table "notification_groups", force: :cascade do |t|
+    t.string   "name"
+    t.string   "notification_type"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -375,4 +393,6 @@ ActiveRecord::Schema.define(version: 20160318135317) do
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   add_index "versions", ["transaction_id"], name: "index_versions_on_transaction_id", using: :btree
 
+  add_foreign_key "notification_group_memberships", "notification_groups"
+  add_foreign_key "notification_group_memberships", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 20160323125120) do
 
   create_table "notification_groups", force: :cascade do |t|
     t.string   "name"
+    t.text     "description"
     t.string   "notification_type"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -1,0 +1,33 @@
+namespace :populate do
+
+  task :special_events_approval_notification_group => :environment do
+    url = "https://github.com/postcode/senoia/files/182245/Special.Event.Plan.Approval.Notification.Group.txt"
+
+    users = open(url).read.split("\r\n").reject(&:blank?)[2..-1].map{|x| x.split("\t") }.map do |name, email|
+      user = User.where("LOWER(email) = ?", email.strip.downcase).first
+      if user
+        puts "#{email} already exists"
+      else
+        user = User.create(name: name.strip, email: email.strip.downcase, password: SecureRandom.hex(16), phone_number: "N/A")
+        puts "Created account for #{email}"
+      end
+      user
+    end
+
+    notification_group = NotificationGroup.where(notification_type: "plan.approved").first_or_create
+    notification_group.update(name: "Special Events Approval Notification Group", description: "Members of this group will be notified of any approved plans.")
+    
+    users.each do |user|
+      membership_relation = NotificationGroupMembership.where(notification_group_id: notification_group.id, user_id: user.id)
+      if membership_relation.any?
+        puts "#{user.email} already in notification group"
+      else
+        membership_relation.first_or_create
+        puts "#{user.email} added to notification group"
+      end
+
+    end
+    
+  end
+  
+end

--- a/spec/acceptance/notifications_spec.rb
+++ b/spec/acceptance/notifications_spec.rb
@@ -117,5 +117,38 @@ feature "Notifications", js: true do
     end
     
   end
+
+  context "Notification Group Member" do
+
+    context "when a plan is approved" do
+
+      let(:plan) { create(:plan_under_review) }
+      let(:group_member) { create(:user) }
+      let(:notification_group) { create(:notification_group, notification_type: "plan.approved") }
+      
+      before do
+        notification_group.members << group_member
+        sign_in(admin)
+        visit "/plans/#{plan.id}"
+        click_link "APPROVE PLAN"
+        sign_out
+      end
+      
+      scenario "receives an email notification" do
+        email = find_email(group_member.email)
+        expect(email).to_not be_nil
+        expect(email).to have_body_text("approved")
+      end
+
+      scenario "receives an on-site notification" do
+        sign_in(group_member)
+        visit "/plans"
+        notification = find(".alert-box", text: plan.name)
+        expect(notification).to have_content("approved")
+      end
+
+    end
+    
+  end
   
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,16 +1,26 @@
 FactoryGirl.define do
- factory :user do
+  factory :user do
     email { Faker::Internet.email }
     first_name Faker::Name.name
     password "password"
     password_confirmation "password"
     confirmed_at Date.today
+    name { Faker::Name.name }
+    phone_number { Faker::PhoneNumber.phone_number }
 
     factory :medical_contact do
       after(:create) do |user, evaluator|
         provider = create(:provider)
         provider.contact_users << user
       end
+    end
+
+    factory :admin do
+      roles "admin"
+    end
+
+    factory :promoter do
+      roles "promoter"
     end
   end
 
@@ -75,33 +85,22 @@ FactoryGirl.define do
     name Faker::Lorem.words(3).join(" ")
   end
 
-  factory :admin, :class => User do |u|
-    u.email { Faker::Internet.email }
-    u.password "password"
-    u.password_confirmation "password"
-    u.roles 'admin'
-    u.confirmed_at Date.today
-  end
-
-  factory :promoter, :class => User do |u|
-    u.email { Faker::Internet.email }
-    u.password "password"
-    u.password_confirmation "password"
-    u.roles 'promoter'
-    u.confirmed_at Date.today
-  end
-
   factory :event_type do
     name { Faker::Lorem.words(3).join(" ") }
   end
 
   factory :provider do
-    name { Faker::Lorem.words(3).join(" ") }
+    name { Faker::Lorem.words(3).join(" ") } 
   end
 
   factory :supplementary_document do
     parent { plan }
     name { Faker::Lorem.words(3).join(" ") }
     file { Rack::Test::UploadedFile.new(File.join(Rails.root, 'README.rdoc')) }
+  end
+
+  factory :notification_group do
+    name { Faker::Lorem.words(3).join(" ") }
+    notification_type "plan.approved"
   end
 end

--- a/spec/models/notification_group_membership_spec.rb
+++ b/spec/models/notification_group_membership_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe NotificationGroupMembership, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/notification_group_spec.rb
+++ b/spec/models/notification_group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe NotificationGroup, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Adds "Notification Groups", which are configured to fire a notification to their members when a specific event occurs.

Notification Groups are listed at the Admin index. Admins can manage the group member list. Otherwise, groups are not user-editable, and admins cannot add new groups. (This is simple to add later if need be.)

Includes a rake task that populates the Special Events Approval Notification Group. The task will create accounts for missing users (and send confirmation emails.) 

To run:
`rake populate:special_events_approval_notification_group`

Fixes #216.
