### PR TITLE
Display Consistent Alerts

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,7 +29,8 @@ class CommentsController < ApplicationController
     @plan = Plan.find(params[:plan_id])
     authorize! :manage, @plan
     @comment = @plan.comments.create(comment_params.merge(user: current_user, element_id: params[:element_id]))
-
+    @comment.send_notifications!
+    
     respond_to do |format|
       format.js
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,6 @@ class HomeController < ApplicationController
   def index
     @plans = Plan.all
     @operation_period = OperationPeriod.all
-    @invitations = current_user.try(:invitations) || []
     
     respond_to do |format|
       format.html

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -3,14 +3,12 @@ class InvitationsController < ApplicationController
   def create
     @plan = Plan.find(params[:plan_id])
     authorize! :manage, @plan
-    if User.find_by_email(invitation_params[:email])
-      @invitation = @plan.invitations.create(invitation_params)
-      if @invitation.valid?
-        @invitation.send_collaboration_email!
-      end
-    else
-      @invitation = @plan.invitations.create(invitation_params)
-      if @invitation.valid?
+    @invitation = @plan.invitations.create(invitation_params)
+    
+    if @invitation.valid?
+      if @invitation.claimed? # User already has an account, send notification
+        @invitation.send_notifications!
+      else # User doesn't have an account, send invitation
         @invitation.send_invitation_email!
       end
     end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -3,7 +3,7 @@ class InvitationsController < ApplicationController
   def create
     @plan = Plan.find(params[:plan_id])
     authorize! :manage, @plan
-    if User.where(email: invitation_params[:email]).present?
+    if User.find_by_email(invitation_params[:email])
       @invitation = @plan.invitations.create(invitation_params)
       if @invitation.valid?
         @invitation.send_collaboration_email!

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -8,12 +8,4 @@ class InvitationMailer < ActionMailer::Base
     mail(to: @email,
          subject: "You have been invited to collaborate on the medical plan #{@plan.name}")
   end
-
-  def collaborate(options = { email: nil, plan: nil })
-    @plan = options[:plan]
-    @email = options[:email]
-    mail(to: @email,
-         subject: "You have been invited to collaborate on the medical plan #{@plan.name}")
-  end
-
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -26,6 +26,10 @@ class Invitation < ActiveRecord::Base
       self.claim!(user)
     end
   end
+
+  def claimed?
+    self.invited_user.present?
+  end
   
   def claim!(user)
     transaction do
@@ -40,11 +44,16 @@ class Invitation < ActiveRecord::Base
     end
   end
 
+  def send_notifications!
+    user.notifications.create(subject: self, key: "created")
+  end
+
   def send_invitation_email!
     InvitationMailer.invite(email: email, plan: plan).deliver_later
   end
 
-  def send_collaboration_email!
-    InvitationMailer.collaborate(email: email, plan: plan).deliver_later
+  def to_s
+    self.plan.try(:to_s)
   end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,11 @@ class User < ActiveRecord::Base
   after_create do
     Invitation.claim_invitations(self)
   end
+
+  def self.find_by_email(email)
+    return nil if email.blank?
+    User.where("LOWER(email) = ?", email.downcase).first
+  end
   
   def to_s
     if name.blank?

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
   <div class="large-5 medium-7 small-9 columns end">
     <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="form-inputs">
-        <%= f.input :email, required: false, autofocus: true %>
+        <%= f.input :email, required: false, autofocus: true, input_html: { value: params[:email] } %>
         <%= f.input :password, required: false %>
         <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
       </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,13 +1,6 @@
 <div class="landing">
   <div id="homepage-hero">
   <div class="row">
-    <div class="large-12 columns pageTitle">
-      <% @invitations.each do |invitation| %>
-        <div data-alert class="alert-box info radius">
-          You were invited to collaborate on the plan <%= link_to invitation.plan.name, invitation.plan %>.
-        </div>
-      <% end %>
-    </div>  
     <div class="large-4 columns">
       <%= link_to new_plan_path do %>
         <div class="main-section">

--- a/app/views/notification_mailer/invitation/_created.html.erb
+++ b/app/views/notification_mailer/invitation/_created.html.erb
@@ -1,0 +1,9 @@
+<p>
+  You have been invited to collaborate on the medical plan titled <%= @invitation.plan.try(:name) %>.
+</p>
+
+<p>
+  Please sign in through the link below to view the plan.
+</p>
+
+<%= link_to "Sign in", new_user_session_url(email: @recipient.email) %>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,5 +1,5 @@
 <div data-alert class="alert-box info radius">
-  <%= render [ "notifications", notification.partial ].join("/"), notification: notification, "#{notification.subject_type.underscore}" => notification.subject %>
+  <%= render [ "notifications", notification.partial ].join("/"), subject: notification.subject, notification: notification, "#{notification.subject_type.underscore}" => notification.subject %>
   <div class="right" style="margin-right: 1em; color: gray">
     <em>
       <%= time_ago_in_words(notification.created_at) %> ago

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,5 +1,5 @@
 <div data-alert class="alert-box info radius">
-  <%= render [ "notifications", notification.partial ].join("/"), subject: notification.subject, notification: notification, "#{notification.subject_type.underscore}" => notification.subject %>
+  <%= render [ "notifications", notification.partial ].join("/"), subject: notification.subject, notification: notification, "#{notification.subject_type.underscore}".to_sym => notification.subject %>
   <div class="right" style="margin-right: 1em; color: gray">
     <em>
       <%= time_ago_in_words(notification.created_at) %> ago

--- a/app/views/notifications/comment/_created.html.erb
+++ b/app/views/notifications/comment/_created.html.erb
@@ -1,1 +1,1 @@
-<%= subject.user %> <%= link_to "commented", subject %> on <%= subject.commentable %>.
+<%= comment.user %> <%= link_to "commented", comment %> on <%= comment.commentable %>.

--- a/app/views/notifications/comment/_created.html.erb
+++ b/app/views/notifications/comment/_created.html.erb
@@ -1,1 +1,1 @@
-<%= comment.user %> <%= link_to "commented", comment %> on <%= comment.commentable %>.
+<%= subject.user %> <%= link_to "commented", subject %> on <%= subject.commentable %>.

--- a/app/views/notifications/invitation/_created.html.erb
+++ b/app/views/notifications/invitation/_created.html.erb
@@ -1,0 +1,1 @@
+You were invited to collaborate on the plan titled <%= link_to subject.plan, subject.plan %>.

--- a/app/views/notifications/invitation/_created.html.erb
+++ b/app/views/notifications/invitation/_created.html.erb
@@ -1,1 +1,1 @@
-You were invited to collaborate on the plan titled <%= link_to subject.plan, subject.plan %>.
+You were invited to collaborate on the plan titled <%= link_to invitation.plan, invitation.plan %>.

--- a/app/views/notifications/plan/_approved.html.erb
+++ b/app/views/notifications/plan/_approved.html.erb
@@ -1,1 +1,1 @@
-<%= link_to notification.subject, notification.subject %> was approved.
+<%= link_to plan, plan %> was approved.

--- a/app/views/notifications/plan/_rejected.html.erb
+++ b/app/views/notifications/plan/_rejected.html.erb
@@ -1,1 +1,1 @@
-<%= link_to notification.subject, notification.subject %> was rejected.
+<%= link_to plan, plan %> was rejected.

--- a/app/views/notifications/plan/_revision_requested.html.erb
+++ b/app/views/notifications/plan/_revision_requested.html.erb
@@ -1,1 +1,1 @@
-<%= link_to notification.subject, notification.subject %> needs revision.
+<%= link_to plan, plan %> needs revision.

--- a/app/views/notifications/plan/_submitted.html.erb
+++ b/app/views/notifications/plan/_submitted.html.erb
@@ -1,1 +1,1 @@
-New plan submitted: <%= link_to notification.subject, notification.subject %>.
+New plan submitted: <%= link_to plan, plan %>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,3 +67,5 @@ en:
         revision_requested: "Medical plan %{subject} needs revision"
         approved: "Your medical plan %{subject} has been approved"
         rejected: "Your medical plan %{subject} has been rejected"
+      invitation:
+        created: "You have been invited to collaborate on the medical plan %{subject}"


### PR DESCRIPTION
Removes separate notifications about collaboration invitations, and moves notifying about collaborations to a Notification.

Users who don't have an existing Senoia account will be notified about invitations only by email.

Additionally, fixes:
- bug where collaboration invitations to existing users would never get claimed.
- bug where onsite notifications would display incorrectly or crash
- bug where root-level comments wouldn't trigger notifications

Fixes #172.
