### PR TITLE
Change language of 'save asset' buttons

### DIFF
--- a/app/views/plans/_new_dispatch.html.erb
+++ b/app/views/plans/_new_dispatch.html.erb
@@ -29,7 +29,7 @@
     <% end %>
   </div>
   <div class="modal-footer">
-    <%= button_to "Add Dispatch", "javascript:void(0)", class: "save-dispatch button primary save-modal disabled", data: {disable_with: "ADDING..."} %>
+    <%= button_to "Confirm This Asset", "javascript:void(0)", class: "save-dispatch button primary save-modal disabled", data: {disable_with: "ADDING..."} %>
   </div>
   <script>
    $(document).ready(function(){

--- a/app/views/plans/_new_first_aid_station.html.erb
+++ b/app/views/plans/_new_first_aid_station.html.erb
@@ -33,7 +33,7 @@
     <% end %>
   </div>
   <div class="modal-footer">
-    <%= link_to "Add First Aid Station", "javascript:void(0)", class: "save-first-aid-station button primary save-modal disabled" %>
+    <%= link_to "Confirm This Asset", "javascript:void(0)", class: "save-first-aid-station button primary save-modal disabled" %>
   </div>
   <script>
    $(document).ready(function(){

--- a/app/views/plans/_new_mobile_team.html.erb
+++ b/app/views/plans/_new_mobile_team.html.erb
@@ -32,7 +32,7 @@
     <% end %>
   </div>
   <div class="modal-footer">
-    <%= link_to "Add Mobile Team", "javascript:void(0)", class: "save-mobile-team button primary save-modal" %>
+    <%= link_to "Confirm This Asset", "javascript:void(0)", class: "save-mobile-team button primary save-modal" %>
   </div>
   <script>
    $(document).ready(function(){

--- a/app/views/plans/_new_transport.html.erb
+++ b/app/views/plans/_new_transport.html.erb
@@ -29,7 +29,7 @@
     <% end %>
   </div>
   <div class="modal-footer">
-    <%= link_to "Add TRANSPORT", "javascript:void(0)", class: "save-transport button primary save-modal disabled" %>
+    <%= link_to "Confirm This Asset", "javascript:void(0)", class: "save-transport button primary save-modal disabled" %>
   </div>
   <script>
    $(document).ready(function(){

--- a/spec/acceptance/plans_spec.rb
+++ b/spec/acceptance/plans_spec.rb
@@ -126,7 +126,7 @@ feature "Plan" do
       end
       expect { 
 
-        click_on "Add First Aid Station"
+        click_on "Confirm This Asset"
 
         expect(page).to have_content first_aid_station_name
       }.to change{ FirstAidStation.count }.by(1)
@@ -285,7 +285,7 @@ feature "Plan" do
         fill_in 'Name', with: first_aid_station_name
       end
 
-      click_on "Add First Aid Station"
+      click_on "Confirm This Asset"
 
       expect(page).to have_content first_aid_station_name
 

--- a/spec/acceptance/provider_confirmation_spec.rb
+++ b/spec/acceptance/provider_confirmation_spec.rb
@@ -26,7 +26,7 @@ feature "Medical Provider Confirmation" do
           fill_in 'Name', with: Faker::Lorem.word
         end
         select provider.name, from: "Provider"
-        click_on "Add First Aid Station"
+        click_on "Confirm This Asset"
         sign_out
         @email = find_email(contact.email)
       end


### PR DESCRIPTION
Changes label of 'save' buttons in asset popups to "Confirm This Asset".

Fixes #199.
