### PR TITLE
Change 'clone' button label to 'create duplicate'

### DIFF
--- a/app/views/operation_periods/_form.html.erb
+++ b/app/views/operation_periods/_form.html.erb
@@ -4,7 +4,7 @@
     <% if op.object.persisted? %>
       <div class="row">
         <div class="large-12 columns">
-          <%= link_to "Clone", [ operation_period, :clones ], method: "POST", remote: true, class: "button primary tiny radius" %>
+          <%= link_to "Create Duplicate Operation Period", [ operation_period, :clones ], method: "POST", remote: true, class: "button primary tiny radius" %>
           <%= link_to operation_period, method: "DELETE", remote: true, class: "button alert right tiny radius", data: { confirm: "Are you sure you want to remove this operational period?" } do %>
             <i class="fi-x"></i>
             Remove

--- a/spec/acceptance/plans_spec.rb
+++ b/spec/acceptance/plans_spec.rb
@@ -95,7 +95,7 @@ feature "Plan" do
       fill_in "operation_period_end_date", with: "02/01/2020 08:00 am"
       expect { 
         find(".save-operation-period").trigger("click")
-        expect(page).to have_content("Clone")
+        expect(page).to have_content("Create Duplicate Operation Period")
       }.to change { OperationPeriod.count }.by(1)
     end
 
@@ -245,7 +245,7 @@ feature "Plan" do
     end
     
     scenario "admin can clone an operation period", js: true do
-      click_on "Clone"
+      click_on "Create Duplicate Operation Period"
       expect(page).to have_selector("#operation-period-tabs li", count: 2)
       click_on "Operational Period 2"
 


### PR DESCRIPTION
Changes the "Clone" button text to "Create Duplicate Operation Period."
