### PR TITLE
Fix operational period tab replacement problem

### DIFF
--- a/app/views/operation_periods/create.js.erb
+++ b/app/views/operation_periods/create.js.erb
@@ -2,7 +2,7 @@
 <% if @count == 1 %>
   $(".operation-period-container").prepend("<%= j render(partial: 'plans/operation_period_button', locals: { plan: @plan } ) %>")
 <% end %>
-$(".tabs-content").html("<%= j render(partial: 'operation_periods/form', locals: { f: f, operation_period: @operation_period, count: @count } )%>")
+$(".tabs-content .active").replaceWith("<%= j render(partial: 'operation_periods/form', locals: { f: f, operation_period: @operation_period, count: @count } )%>")
 $(".tabs .active").replaceWith('<li class="tab-title"><a href="#panel<%= @count %>">Operational Period <%= @count %></a></li>')
 $('.dateSelect').fdatepicker({
     format: 'mm/dd/yyyy'


### PR DESCRIPTION
Currently, creasing a new operational period would overwrite all existing tabs. This fixes that. 
Closes #325
Closes #328
