### PR TITLE
Add better crowd size error messages

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -8,6 +8,7 @@ $recordtracred: #EC916F;
 $green: #86CDB2;
 $orange: #EEA758;
 $yellow: #EDD364;
+$alert-color: #f04124;
 
 /* Element Colors */
 $typography: #58585B;

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -150,6 +150,14 @@ legend{
   margin-bottom: 1em;
 }
 
+/* Error handling */
+#error_explanation {
+  h4,
+  ul {
+    color: $alert-color;
+  }
+}
+
 /* LANDING PAGE */
 .landing{
   h1 {
@@ -627,12 +635,12 @@ div.input.radio_buttons {
 /* Communication Plan */
 #communication-plan{
   .input_label{
-    margin-bottom: 2em; 
+    margin-bottom: 2em;
   }
   .input_label label {
       font-weight: normal;
       text-transform: none;
-  }  
+  }
   .input{
     margin-bottom: 1em;
   }

--- a/app/models/operation_period.rb
+++ b/app/models/operation_period.rb
@@ -31,6 +31,7 @@ class OperationPeriod < ActiveRecord::Base
   validates :start_date, presence: true
   validates :end_date, presence: true
   validates :attendance, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :crowd_estimate, numericality: { only_integer: true, greater_than: 0, allow_blank: true }
 
   include CustomDateTimeFormat
   use_custom_datetime_format_for :start_date, :end_date

--- a/app/views/plans/edit.html.erb
+++ b/app/views/plans/edit.html.erb
@@ -1,13 +1,19 @@
 <%= simple_form_for @plan do |f| %>
   <% if @plan.errors.any? %>
-    <div id="error_explanation">
-      <h4><%= pluralize(@plan.errors.count, "error") %> prohibited this plan from being saved:</h4>
-      <ul>
-        <% @plan.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
+  <div class="large-12 columns">
+    <div class="row">
+      <div class="large-12 columns">
+        <div id="error_explanation">
+          <h4><%= pluralize(@plan.errors.count, "error") %> prohibited this plan from being saved:</h4>
+          <ul>
+            <% @plan.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
     </div>
+  </div>
   <% end %>
   <div class="large-12 columns">
     <div class="row">
@@ -25,10 +31,10 @@
     <div class="row">
       <div class="large-8 columns">
         <fieldset>
-          <legend>EVENT PLAN CREATOR</legend>   
+          <legend>EVENT PLAN CREATOR</legend>
           <% if @plan.creator.present? %>
             <p><i class="fi-mail"></i> <%= @plan.creator.email %></p>
-            <p><i class="fi-telephone"></i> <%= @plan.creator.phone_number %></p>   
+            <p><i class="fi-telephone"></i> <%= @plan.creator.phone_number %></p>
           <% else %>
             <%= f.association :creator,
                               collection: User.all,
@@ -36,8 +42,8 @@
                               value_method: :id,
                               include_blank: false,
                               label: false %>
-          <% end %> 
-        </fieldset>   
+          <% end %>
+        </fieldset>
       </div>
       <div class="large-4 columns end">
         <%= render 'comment_form', plan: @plan, title: "contact" %>
@@ -64,7 +70,7 @@
                   <% end %>
                 </tbody>
               </table>
-            </div>  
+            </div>
             <div class="large-3 columns">
               <a id="new_plan_user_button" href="#" data-reveal-id="new-plan-user" class="button tiny radius"><i class="fi-plus"></i> ADD USERS</a>
               <%= render 'new_plan_user', :plan => @plan %>
@@ -77,7 +83,7 @@
           <%= render 'comment_form', plan: @plan, title: "collaborators" %>
         <% end %>
       </div>
-    </div>          
+    </div>
   </div>
   <div class="row">
     <div class="small-3 columns input_label">
@@ -135,7 +141,7 @@
     <div class="small-3 columns input_label">
       <%= f.label :venue_id, class: "inline", required: false %>
     </div>
-    <div class="small-5 columns input_label">  
+    <div class="small-5 columns input_label">
       <%= f.association :venues, input_html: {class: "chosen-input", placeholder: "Type a venue name", multiple: false}, label: false %>
     </div>
     <div class="large-4 columns end">
@@ -155,15 +161,15 @@
             <%= f.input :post_event_name, required: true %>
             <%= f.input :post_event_email, required: true %>
             <%= f.input :post_event_phone, required: true %>
-          </div>  
-        </div>     
-      </fieldset>  
+          </div>
+        </div>
+      </fieldset>
     </div>
 
   <% if can? :edit, @plan %>
     <%= render 'actions', f: f, plan: @plan %>
   <% end %>
-<% end %> 
+<% end %>
 
 <script>
   $('.chosen-input').chosen({

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,9 +23,6 @@ en:
   hello: "Hello world"
 
   activerecord:
-    attributes:
-      operation_period:
-        attendance: "Operational Period Attendance"
     errors:
       models:
         operation_period:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,21 @@
 en:
   hello: "Hello world"
 
+  activerecord:
+    attributes:
+      operation_period:
+        attendance: "Operational Period Attendance"
+    errors:
+      models:
+        operation_period:
+          attributes:
+            attendance:
+              not_a_number: "should be a number without commas or letters"
+              not_an_integer: "should be a number without commas or letters"
+            crowd_estimate:
+              not_a_number: "should be a number without commas or letters"
+              not_an_integer: "should be a number without commas or letters"
+
   simple_form:
     labels:
       plan: &PlanAttributes
@@ -32,7 +47,6 @@ en:
   plans:
     show: *PlanAttributes
 
-  
   time:
     formats:
       default: "%m/%d/%Y %l:%M %P"
@@ -57,7 +71,6 @@ en:
     form: *PostEventTreatmentReportAttributes
     post_event_treatment_report: *PostEventTreatmentReportAttributes
 
-      
   notification_mailer:
     subject:
       comment:


### PR DESCRIPTION
Addresses #268 

@ttmp  It looked like it would take fighting to get the error message wording exactly as specified in #268 because of the way the rails error formatting works. You or @andyhull might have a quick solution. This isn't perfect but gets the message across: 

![screen shot 2016-06-06 at 4 51 36 pm](https://cloud.githubusercontent.com/assets/86435/15837399/18b894de-2c07-11e6-9e45-7eacd85e5a46.png)
![screen shot 2016-06-06 at 4 51 14 pm](https://cloud.githubusercontent.com/assets/86435/15837400/18b926e2-2c07-11e6-99f1-ea3667d488ac.png)
