### PR TITLE
Update new users admin path, closes #322

### DIFF
--- a/app/views/users/_new.html.erb
+++ b/app/views/users/_new.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @user, url: new_users_admin_path, html: { method: :get } do |f| %>
+<%= simple_form_for @user, url: users_admin_index_path do |f| %>
 <% if @user.errors.any? %>
 <div id="error_explanation">
   <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>


### PR DESCRIPTION
By using GET, we lost nice error messages (user creation would fail silently). 
